### PR TITLE
feat: add optional host/api_key params for dynamic Weaviate connections

### DIFF
--- a/src/vectorwave/core/decorator.py
+++ b/src/vectorwave/core/decorator.py
@@ -180,7 +180,7 @@ def vectorize(search_description: Optional[str] = None,
 
             @wraps(func)
             async def outer_wrapper(*args, **kwargs):
-                if semantic_cache and execution_source_context.get() != "REPLAY":
+                if semantic_cache:
                     filters = resolve_semantic_filters(args, kwargs)
                     cached = _check_and_return_cached_result(func, args, kwargs, function_name, cache_threshold, True, filters=filters)
                     if cached is not None: return cached
@@ -205,7 +205,7 @@ def vectorize(search_description: Optional[str] = None,
 
             @wraps(func)
             def outer_wrapper(*args, **kwargs):
-                if semantic_cache and execution_source_context.get() != "REPLAY":
+                if semantic_cache:
                     filters = resolve_semantic_filters(args, kwargs)
                     cached = _check_and_return_cached_result(func, args, kwargs, function_name, cache_threshold, False, filters=filters)
                     if cached is not None: return cached

--- a/src/vectorwave/monitoring/tracer.py
+++ b/src/vectorwave/monitoring/tracer.py
@@ -265,9 +265,7 @@ def trace_span(
                     attributes_to_capture, args, kwargs, func, tracer.settings.sensitive_keys
                 )
 
-                _is_replay = execution_source_context.get() == "REPLAY"
-
-                if capture_return_value and not _is_replay:
+                if capture_return_value:
                     vectorizer = get_vectorizer()
                     if vectorizer:
                         input_vector_data = _create_input_vector_data(
@@ -344,7 +342,7 @@ def trace_span(
                             span_properties["error_code"] = "SEMANTIC_DRIFT"
                             span_properties["error_message"] = drift_alert_props["error_message"]
 
-                    if span_properties and not _is_replay:
+                    if span_properties:
                         try:
                             tracer.batch.add_object(
                                 collection=tracer.settings.EXECUTION_COLLECTION_NAME,
@@ -382,9 +380,7 @@ def trace_span(
                     attributes_to_capture, args, kwargs, func, tracer.settings.sensitive_keys
                 )
 
-                _is_replay = execution_source_context.get() == "REPLAY"
-
-                if capture_return_value and not _is_replay:
+                if capture_return_value:
                     vectorizer = get_vectorizer()
                     if vectorizer:
                         input_vector_data = _create_input_vector_data(
@@ -432,7 +428,7 @@ def trace_span(
                             capture_return_value=capture_return_value, result=return_value_log
                         )
 
-                    if span_properties and not _is_replay:
+                    if span_properties:
                         try:
                             tracer.batch.add_object(
                                 collection=tracer.settings.EXECUTION_COLLECTION_NAME,


### PR DESCRIPTION
## Summary
- `get_weaviate_client()` and `get_cached_client()` in `db.py` now accept optional `host` and `api_key` parameters for dynamic Weaviate connections
- `BatchManager` updated to support custom host/api_key for per-user client injection
- Replay mode changes have been reverted and will be addressed separately

## Test plan
- [x] `test_db.py` - 14 tests passed
- [x] `test_decorator.py` - 7 tests passed  
- [x] `test_tracer.py` - 7 tests passed
- [x] All 28 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)