### PR TITLE
release: v0.3.0

### DIFF
--- a/src/vectorwave/core/decorator.py
+++ b/src/vectorwave/core/decorator.py
@@ -31,6 +31,7 @@ def vectorize(search_description: Optional[str] = None,
               capture_inputs: bool = False,
               semantic_cache_filters: Optional[Dict[str, Any]] = None,
               semantic_cache_scope: Optional[List[str]] = None,
+              enable_alert: bool = True,
               **execution_tags):
     """
     VectorWave Decorator with Auto-Generation support.
@@ -199,7 +200,8 @@ def vectorize(search_description: Optional[str] = None,
             @trace_span(
                 attributes_to_capture=final_attributes,
                 capture_return_value=capture_return_value,
-                force_sync=semantic_cache
+                force_sync=semantic_cache,
+                enable_alert=enable_alert
             )
             @wraps(func)
             async def inner_wrapper(*args, **kwargs):
@@ -222,7 +224,8 @@ def vectorize(search_description: Optional[str] = None,
             @trace_span(
                 attributes_to_capture=final_attributes,
                 capture_return_value=capture_return_value,
-                force_sync=semantic_cache
+                force_sync=semantic_cache,
+                enable_alert=enable_alert
             )
             @wraps(func)
             def inner_wrapper(*args, **kwargs):

--- a/src/vectorwave/utils/replayer_semantic.py
+++ b/src/vectorwave/utils/replayer_semantic.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..core.llm.factory import get_llm_client
 from .replayer import VectorWaveReplayer
@@ -25,7 +25,8 @@ class SemanticReplayer(VectorWaveReplayer):
                limit: int = 10,
                update_baseline: bool = False,
                similarity_threshold: Optional[float] = None,
-               semantic_eval: bool = False
+               semantic_eval: bool = False,
+               mocks: Optional[Dict[str, Any]] = None
                ) -> Dict[str, Any]:
         """
         Retrieves past execution history (Golden > Standard), re-executes it,
@@ -47,7 +48,7 @@ class SemanticReplayer(VectorWaveReplayer):
             )
             return is_match, reason, ({"reason": reason} if not is_match else {})
 
-        return self._run_replay_loop(target_func, test_objects, results, update_baseline, compare_fn)
+        return self._run_replay_loop(target_func, test_objects, results, update_baseline, compare_fn, mocks=mocks)
 
     def _compare_results_semantic(self, expected: Any, actual: Any,
                                   similarity_threshold: Optional[float],

--- a/test_ex/replay_demo.py
+++ b/test_ex/replay_demo.py
@@ -1,0 +1,251 @@
+"""
+replay_demo.py - Replay 기능 실제 동작 테스트 (외부 호출 없음)
+
+실행 방법:
+  python3 test_ex/replay_demo.py
+  pytest test_ex/replay_demo.py -v
+"""
+
+import importlib
+import json
+import inspect
+import sys
+from unittest.mock import MagicMock, patch
+
+# test_ex/replay_fixtures 가 항상 동일한 경로로 임포트되도록 보장
+import test_ex.replay_fixtures as _fx
+
+
+# ── Weaviate Mock 구성 ────────────────────────────────────────────────────────
+
+def _make_mock_weaviate(exec_logs=None):
+    mock_settings = MagicMock()
+    mock_settings.EXECUTION_COLLECTION_NAME = "VectorWaveExecutions"
+    mock_settings.GOLDEN_COLLECTION_NAME = "VectorWaveGoldenDataset"
+
+    mock_exec_col = MagicMock()
+    mock_golden_col = MagicMock()
+
+    mock_exec_col.query.fetch_objects.return_value = MagicMock(objects=exec_logs or [])
+    mock_exec_col.query.fetch_object_by_id.return_value = None
+    mock_exec_col.data = MagicMock()
+
+    mock_golden_col.query.fetch_objects.return_value = MagicMock(objects=[])
+    mock_golden_col.data = MagicMock()
+
+    mock_client = MagicMock()
+
+    def _get_col(name):
+        if name == "VectorWaveGoldenDataset":
+            return mock_golden_col
+        return mock_exec_col
+
+    mock_client.collections.get.side_effect = _get_col
+    return mock_client, mock_settings, mock_exec_col
+
+
+def _make_log(uuid_str: str, inputs: dict, return_value) -> MagicMock:
+    obj = MagicMock()
+    obj.uuid = uuid_str
+    props = inputs.copy()
+    props["return_value"] = (
+        json.dumps(return_value) if not isinstance(return_value, str) else return_value
+    )
+    props["timestamp_utc"] = "2024-01-01T00:00:00Z"
+    obj.properties = props
+    return obj
+
+
+def _run_replay(func_full_name: str, func_obj, logs: list,
+                mocks=None, update_baseline: bool = False) -> dict:
+    mock_client, mock_settings, mock_exec_col = _make_mock_weaviate(exec_logs=logs)
+
+    func_name = func_full_name.rsplit(".", 1)[1]
+    mock_module = MagicMock()
+    setattr(mock_module, func_name, func_obj)
+
+    mock_importlib = MagicMock(spec=importlib)
+    mock_importlib.import_module.return_value = mock_module
+
+    with patch("vectorwave.utils.replayer.get_cached_client", return_value=mock_client), \
+         patch("vectorwave.utils.replayer.get_weaviate_settings", return_value=mock_settings), \
+         patch("vectorwave.utils.replayer.importlib", mock_importlib):
+
+        from vectorwave.utils.replayer import VectorWaveReplayer  # noqa: PLC0415
+        replayer = VectorWaveReplayer()
+
+        return replayer.replay(
+            func_full_name, limit=len(logs),
+            mocks=mocks, update_baseline=update_baseline
+        ), mock_exec_col
+
+
+# ── 테스트 케이스 ─────────────────────────────────────────────────────────────
+
+def test_순수로직_매치():
+    """외부 호출 없는 순수 함수: 예상값과 일치 → PASSED"""
+    logs = [_make_log("uuid-1", {"a": 3, "b": 4}, 7)]
+    result, _ = _run_replay("test_ex.replay_fixtures.add", _fx.add, logs)
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_순수로직_매치")
+
+
+def test_순수로직_불일치():
+    """함수 결과가 기록된 기대값과 다를 때 → FAILED (회귀 감지)"""
+    def buggy_add(a: int, b: int) -> int:
+        return a + b + 100  # 버그
+
+    buggy_add.__signature__ = inspect.signature(_fx.add)
+
+    logs = [_make_log("uuid-2", {"a": 3, "b": 4}, 7)]
+    result, _ = _run_replay("test_ex.replay_fixtures.add", buggy_add, logs)
+
+    assert result["passed"] == 0
+    assert result["failed"] == 1
+    assert result["failures"][0]["expected"] == 7
+    assert result["failures"][0]["actual"] == 107
+    print("[OK] test_순수로직_불일치")
+
+
+def test_외부호출_mocks로_차단():
+    """
+    process_order 는 _external_payment_api 를 호출한다.
+    mocks 파라미터로 해당 호출을 차단하고 가짜 응답을 주입한다.
+    """
+    expected_payment = {"status": "approved", "amount": 50.0}
+    logs = [
+        _make_log(
+            "uuid-3",
+            {"item": "book", "quantity": 2, "price_per_unit": 25.0},
+            {"item": "book", "quantity": 2, "payment": expected_payment},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks={
+            "test_ex.replay_fixtures._external_payment_api": {
+                "return_value": expected_payment
+            }
+        },
+    )
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_외부호출_mocks로_차단")
+
+
+def test_외부호출_차단없이_실행시_예외처리():
+    """mocks 없이 외부 호출 함수 실행 → RuntimeError → failed 로 기록됨"""
+    logs = [
+        _make_log(
+            "uuid-4",
+            {"item": "pen", "quantity": 1, "price_per_unit": 5.0},
+            {"item": "pen", "payment": {"status": "approved"}},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks=None,
+    )
+
+    assert result["failed"] == 1
+    assert "EXCEPTION_RAISED" in str(result["failures"][0]["actual"])
+    print("[OK] test_외부호출_차단없이_실행시_예외처리")
+
+
+def test_mocks_side_effect():
+    """side_effect 로 입력값 기반 동적 응답 주입"""
+    def dynamic_payment(amount):
+        return {"status": "approved", "amount": amount * 0.9}
+
+    logs = [
+        _make_log(
+            "uuid-5",
+            {"item": "hat", "quantity": 2, "price_per_unit": 30.0},
+            {"item": "hat", "quantity": 2,
+             "payment": {"status": "approved", "amount": 54.0}},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks={
+            "test_ex.replay_fixtures._external_payment_api": {
+                "side_effect": dynamic_payment
+            }
+        },
+    )
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_mocks_side_effect")
+
+
+def test_update_baseline():
+    """update_baseline=True: 결과가 달라도 DB를 업데이트하고 PASSED 처리"""
+    logs = [_make_log("uuid-6", {"name": "Alice"}, "Hello, Bob!")]  # 기대값이 틀림
+
+    mock_client, mock_settings, mock_exec_col = _make_mock_weaviate(exec_logs=logs)
+
+    mock_module = MagicMock()
+    mock_module.greet = _fx.greet
+    mock_importlib = MagicMock(spec=importlib)
+    mock_importlib.import_module.return_value = mock_module
+
+    with patch("vectorwave.utils.replayer.get_cached_client", return_value=mock_client), \
+         patch("vectorwave.utils.replayer.get_weaviate_settings", return_value=mock_settings), \
+         patch("vectorwave.utils.replayer.importlib", mock_importlib):
+
+        from vectorwave.utils.replayer import VectorWaveReplayer  # noqa: PLC0415
+        replayer = VectorWaveReplayer()
+
+        result = replayer.replay(
+            "test_ex.replay_fixtures.greet",
+            limit=1,
+            update_baseline=True,
+        )
+
+    assert result["updated"] == 1
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    mock_exec_col.data.update.assert_called_once()
+    print("[OK] test_update_baseline")
+
+
+# ── 직접 실행 ─────────────────────────────────────────────────────────────────
+
+TESTS = [
+    test_순수로직_매치,
+    test_순수로직_불일치,
+    test_외부호출_mocks로_차단,
+    test_외부호출_차단없이_실행시_예외처리,
+    test_mocks_side_effect,
+    test_update_baseline,
+]
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("VectorWave Replayer 동작 테스트 (외부 호출 없음)")
+    print("=" * 60)
+
+    passed_cnt, failed_cnt = 0, 0
+    for test_fn in TESTS:
+        try:
+            test_fn()
+            passed_cnt += 1
+        except Exception as e:
+            print(f"[FAIL] {test_fn.__name__}: {e}")
+            failed_cnt += 1
+
+    print(f"\n결과: {passed_cnt} passed / {failed_cnt} failed")
+    sys.exit(1 if failed_cnt else 0)

--- a/test_ex/replay_fixtures.py
+++ b/test_ex/replay_fixtures.py
@@ -1,0 +1,26 @@
+"""
+replay_demo에서 사용하는 테스트 대상 함수들.
+별도 모듈로 분리해야 patch 경로('test_ex.replay_fixtures.*')가 항상 일정하다.
+"""
+
+
+def _external_payment_api(amount: float) -> dict:
+    """실제 환경에서는 외부 결제 API를 호출 - 테스트에서 차단해야 함"""
+    raise RuntimeError("실제 결제 API 호출됨! 테스트에서는 차단되어야 합니다.")
+
+
+def process_order(item: str, quantity: int, price_per_unit: float) -> dict:
+    """주문 처리 함수. 외부 결제 API를 호출한다."""
+    subtotal = quantity * price_per_unit
+    payment_result = _external_payment_api(subtotal)
+    return {"item": item, "quantity": quantity, "payment": payment_result}
+
+
+def add(a: int, b: int) -> int:
+    """순수 로직 함수 (외부 호출 없음)"""
+    return a + b
+
+
+def greet(name: str) -> str:
+    """순수 문자열 처리 함수"""
+    return f"Hello, {name}!"


### PR DESCRIPTION
## Release v0.3.0

Bumps version from `0.2.09` → `0.3.0` in `pyproject.toml`.

---

## Changes since v0.2.9

### Features

**`feat(monitoring)`: Per-function alert control — `f19174f`** (Closes #94)
- Added `enable_alert: bool = True` parameter to `@vectorize` decorator
- Propagated through `trace_span()` → `SpanContext` → `_perform_background_logging()`
- Error alerts (step 6) and semantic drift alerts (step 7) are now gated by `ctx.enable_alert`
- DB logging is always preserved regardless of `enable_alert` value

**`feat(replay)`: Mocks support in replay system — `e311f5b`** (Fixes #104)
- Added `mocks` parameter to `VectorWaveReplayer.replay()` via `contextlib.ExitStack`
- Fixed `SemanticReplayer.replay()` missing `mocks` parameter sync bug
- Fixed Python 3.12 importlib pollution bug in mock patching

**`feat(tracer)`: Fire-and-forget async logging — `6c1fc44`**
- Implemented zero-latency background logging via `ThreadPoolExecutor`
- Added `ASYNC_LOGGING` config flag (`feat(config)` — `464ac1e`)
- Async logging and semantic caching are mutually exclusive (`force_sync=True` when `semantic_cache=True`)

**`feat(db)`: `update_database_schema()` migration utility — `e29e59b`**
- Adds properties from `.weaviate_properties` to existing Weaviate collections without data loss

**`feat(wcs)`: Weaviate Cloud Service connection support — `e9c06c8`**
- Added optional `host` / `api_key` parameters for dynamic Weaviate connections

### Refactor & Fixes

- `refactor`: Code quality improvements and bug fixes across `test_ex/` scripts — `ca3a097`

### Tests

- `test(async_logging)`: Unit tests for async logging and `force_sync` override — `9e7a49a`
- Added 2 tests for `enable_alert` suppression and backward compatibility
- Added 2 tests for replay mock injection (`return_value`, `side_effect`)

---

## Test Results

```
67 passed ← full non-DB test suite (no regressions)
```