### PR TITLE
test: add testcontainers fixture and convert DB tests to e2e

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vectorwave"
-version = "0.2.09"
+version = "0.3.0"
 authors = [
     { name = "junyeonggim", email = "junyeonggim5@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,17 @@ dependencies = [
     "schedule"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "flake8",
+    "testcontainers>=4.0.0",
+]
+
+[project.scripts]
+vectorwave = "vectorwave.cli:main"
+
 [project.urls]
 Repository = "https://github.com/cozymori/vectorwave"
 
@@ -43,3 +54,4 @@ python-source = "src"
 module-name = "vectorwave.vectorwave_core"
 manifest-path = "crates/Cargo.toml"
 features = ["pyo3/extension-module"]
+include = ["src/vectorwave/cli/dev/compose.yml"]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -5,7 +5,27 @@ from vectorwave.batch.batch import get_batch_manager
 import time
 
 CACHE_FILE_PATH = ".vectorwave_functions_cache.json"
+WEAVIATE_IMAGE = "semitechnologies/weaviate:1.28.4"
+
+# Our session fixture explicitly stops the container in its finally, so the
+# testcontainers Reaper (Ryuk) is redundant — and it's been racy on macOS docker
+# desktop. Disable it before any testcontainers imports happen.
+os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
+WEAVIATE_READY_TIMEOUT = 60
+VECTORWAVE_COLLECTIONS = (
+    "VectorWaveFunctions",
+    "VectorWaveExecutions",
+    "VectorWaveGoldenDataset",
+    "VectorWaveTokenUsage",
+)
 logger = logging.getLogger(__name__)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "e2e: requires a real Weaviate instance (provided by the weaviate_container fixture)",
+    )
 
 
 def _delete_cache():
@@ -39,3 +59,98 @@ def shutdown_batch_manager():
             time.sleep(0.1)
     except Exception as e:
         print(f"Cleanup error: {e}")
+
+
+def _clear_vectorwave_singletons():
+    """Reset @lru_cache singletons so they pick up newly-set env vars."""
+    from vectorwave.models.db_config import get_weaviate_settings
+    from vectorwave.database.db import get_cached_client
+    from vectorwave.vectorizer.factory import get_vectorizer
+    from vectorwave.batch.batch import get_batch_manager as _gbm
+    for fn in (get_weaviate_settings, get_cached_client, get_vectorizer, _gbm):
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+
+@pytest.fixture(scope="session")
+def weaviate_container():
+    """
+    Session-scoped Weaviate container started via testcontainers.
+
+    Tests that need a real Weaviate instance request this fixture by name.
+    Boots once per pytest session, sets WEAVIATE_* env vars, and clears
+    VectorWave's @lru_cache singletons so they pick up the new connection.
+    """
+    try:
+        from testcontainers.core.container import DockerContainer
+        from testcontainers.core.waiting_utils import wait_for_logs
+    except ImportError:
+        pytest.skip("testcontainers not installed (pip install 'vectorwave[dev]')")
+
+    container = (
+        DockerContainer(WEAVIATE_IMAGE)
+        .with_env("AUTHENTICATION_ANONYMOUS_ENABLED", "true")
+        .with_env("PERSISTENCE_DATA_PATH", "/var/lib/weaviate")
+        .with_env("CLUSTER_HOSTNAME", "node1")
+        .with_env("DEFAULT_VECTORIZER_MODULE", "none")
+        .with_env("ENABLE_MODULES", "text2vec-openai,generative-openai")
+        .with_env("QUERY_DEFAULTS_LIMIT", "25")
+        .with_exposed_ports(8080, 50051)
+    )
+    container.start()
+    wait_for_logs(container, "Serving weaviate", timeout=WEAVIATE_READY_TIMEOUT)
+
+    host = container.get_container_host_ip()
+    http_port = int(container.get_exposed_port(8080))
+    grpc_port = int(container.get_exposed_port(50051))
+
+    saved_env = {
+        k: os.environ.get(k)
+        for k in (
+            "WEAVIATE_HOST",
+            "WEAVIATE_PORT",
+            "WEAVIATE_GRPC_PORT",
+            "WEAVIATE_API_KEY",
+            "VECTORIZER",
+            "IS_VECTORIZE_COLLECTION_NAME",
+        )
+    }
+    os.environ["WEAVIATE_HOST"] = host
+    os.environ["WEAVIATE_PORT"] = str(http_port)
+    os.environ["WEAVIATE_GRPC_PORT"] = str(grpc_port)
+    os.environ.pop("WEAVIATE_API_KEY", None)
+    os.environ["VECTORIZER"] = "none"
+    os.environ["IS_VECTORIZE_COLLECTION_NAME"] = "False"
+    _clear_vectorwave_singletons()
+
+    try:
+        yield {"host": host, "port": http_port, "grpc_port": grpc_port}
+    finally:
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _clear_vectorwave_singletons()
+        container.stop()
+
+
+@pytest.fixture
+def clean_weaviate(weaviate_container):
+    """Function-scoped fixture: deletes VectorWave collections before and after each test."""
+    from vectorwave.database.db import get_weaviate_client
+
+    def _wipe():
+        client = get_weaviate_client()
+        try:
+            for name in VECTORWAVE_COLLECTIONS:
+                if client.collections.exists(name):
+                    client.collections.delete(name)
+        finally:
+            client.close()
+
+    _wipe()
+    try:
+        yield weaviate_container
+    finally:
+        _wipe()

--- a/src/tests/database/test_archiver.py
+++ b/src/tests/database/test_archiver.py
@@ -1,232 +1,204 @@
-import pytest
 import json
-import uuid
-from unittest.mock import MagicMock, patch, mock_open
-from vectorwave.database.archiver import VectorWaveArchiver
-from vectorwave.models.db_config import WeaviateSettings
-from weaviate.classes.query import Filter as wvc_filter # Import Filter explicitly
+import pytest
+from datetime import datetime, timezone
+from uuid import uuid4
 
-# --- Mock Fixtures ---
+from vectorwave.database.archiver import VectorWaveArchiver
+from vectorwave.database.db import get_weaviate_client, create_execution_schema
+from vectorwave.models.db_config import WeaviateSettings
+
 
 @pytest.fixture
-def mock_archiver_deps(monkeypatch):
-    """
-    Mocks the dependencies (DB client, settings) for Archiver testing.
-    """
-    # 1. Mock Settings
-    mock_settings = WeaviateSettings(EXECUTION_COLLECTION_NAME="TestExecutions")
-    mock_get_settings = MagicMock(return_value=mock_settings)
-
-    # 2. Mock Weaviate Client & Collection
-    mock_client = MagicMock()
-    mock_collection = MagicMock()
-
-    # Set up the fake response object for query.fetch_objects() to return
-    mock_query = MagicMock()
-    mock_collection.query = mock_query
-
-    # Set up the fake result object for data.delete_many() to return
-    mock_data = MagicMock()
-    mock_delete_result = MagicMock()
-    mock_delete_result.successful = 5  # Assume 5 successful deletions
-    mock_data.delete_many.return_value = mock_delete_result
-    mock_collection.data = mock_data
-
-    mock_client.collections.get.return_value = mock_collection
-    mock_get_client = MagicMock(return_value=mock_client)
-
-    # 3. Apply Monkeypatch
-    monkeypatch.setattr("vectorwave.database.archiver.get_cached_client", mock_get_client)
-    monkeypatch.setattr("vectorwave.database.archiver.get_weaviate_settings", mock_get_settings)
-
-    return {
-        "client": mock_client,
-        "collection": mock_collection,
-        "query": mock_query,
-        "data": mock_data,
-        "settings": mock_settings
-    }
-
-def create_mock_object(uuid_str, props):
-    """Helper function to mimic a Weaviate Object"""
-    mock_obj = MagicMock()
-    mock_obj.uuid = uuid_str
-    mock_obj.properties = props
-    return mock_obj
+def e2e_settings() -> WeaviateSettings:
+    s = WeaviateSettings()
+    s.IS_VECTORIZE_COLLECTION_NAME = False
+    s.VECTORIZER = "none"
+    return s
 
 
-# --- Test Cases ---
-
-def test_export_and_clear_success(mock_archiver_deps):
-    """
-    Case 1: [Export + Clear] Normal operation test
-    - Verify successful file saving
-    - Verify DB deletion call
-    """
-    # Arrange
-    valid_uuid_1 = str(uuid.uuid4())
-    valid_uuid_2 = str(uuid.uuid4())
-
-    mock_objects = [
-        create_mock_object(valid_uuid_1, {"function_name": "test_func", "return_value": "res1", "status": "SUCCESS"}),
-        create_mock_object(valid_uuid_2, {"function_name": "test_func", "return_value": "res2", "status": "SUCCESS"})
-    ]
-    mock_archiver_deps["query"].fetch_objects.return_value = MagicMock(objects=mock_objects)
-
-    archiver = VectorWaveArchiver()
-
-    # Act
-    # Mocks os.makedirs and open to prevent actual file creation
-    with patch("os.makedirs") as mock_makedirs, \
-            patch("builtins.open", new_callable=mock_open) as mock_file:
-
-        result = archiver.export_and_clear(
-            function_name="test_func",
-            output_file="data/dataset.jsonl",
-            clear_after_export=True,  # <--- Request deletion after Export
-            delete_only=False
-        )
-
-    # Assert
-    # 1. Check result return value
-    assert result["exported"] == 2
-    assert result["deleted"] == 5  # Mocked value
-
-    # 2. Verify file writing (called 2 times)
-    assert mock_file.call_count == 1  # open() call count
-    handle = mock_file()
-    assert handle.write.call_count == 2 # write() call count (2 data records)
-
-    # 3. Verify DB deletion call (delete_many was called)
-    mock_archiver_deps["data"].delete_many.assert_called_once()
-
-    # 4. Verify directory creation
-    mock_makedirs.assert_called_with("data", exist_ok=True)
-
-
-def test_export_only_no_delete(mock_archiver_deps):
-    """
-    Case 2: [Export Only] Only exports and does not delete
-    """
-    # Arrange
-    valid_uuid = str(uuid.uuid4())
-    mock_objects = [create_mock_object(valid_uuid, {"val": 1})]
-    mock_archiver_deps["query"].fetch_objects.return_value = MagicMock(objects=mock_objects)
-
-    archiver = VectorWaveArchiver()
-
-    # Act
-    with patch("os.makedirs"), patch("builtins.open", new_callable=mock_open):
-        result = archiver.export_and_clear(
-            function_name="test_func",
-            output_file="backup.jsonl",
-            clear_after_export=False, # <--- No deletion
-            delete_only=False
-        )
-
-    # Assert
-    assert result["exported"] == 1
-    assert result["deleted"] == 0
-
-    # DB deletion method should not be called
-    mock_archiver_deps["data"].delete_many.assert_not_called()
-
-
-def test_delete_only_no_export(mock_archiver_deps):
-    """
-    Case 3: [Delete Only] Performs only deletion without saving file (Purge)
-    """
-    # Arrange
-    valid_uuid = str(uuid.uuid4())
-    mock_objects = [create_mock_object(valid_uuid, {"val": 2})]
-    mock_archiver_deps["query"].fetch_objects.return_value = MagicMock(objects=mock_objects)
-
-    archiver = VectorWaveArchiver()
-
-    # Act
-    with patch("builtins.open", new_callable=mock_open) as mock_file:
-        result = archiver.export_and_clear(
-            function_name="test_func",
-            output_file="",
-            clear_after_export=False,
-            delete_only=True  # <--- Delete-only mode
-        )
-
-    # Assert
-    assert result["exported"] == 0
-    assert result["deleted"] == 5
-
-    # File should not be opened
-    mock_file.assert_not_called()
-    # DB deletion should be called
-    mock_archiver_deps["data"].delete_many.assert_called_once()
-
-
-def test_safety_check_file_write_error_prevents_delete(mock_archiver_deps):
-    """
-    Case 4: [Safety] If an error occurs during file saving, DB deletion must be prevented
-    """
-    # Arrange
-    valid_uuid = str(uuid.uuid4())
-    mock_objects = [create_mock_object(valid_uuid, {"data": "ok"})]
-    mock_archiver_deps["query"].fetch_objects.return_value = MagicMock(objects=mock_objects)
-
-    archiver = VectorWaveArchiver()
-
-    # Act
-    # Induce IOError when open() is called
-    with patch("os.makedirs"), \
-            patch("builtins.open", side_effect=IOError("Disk Full")):
-
-        result = archiver.export_and_clear(
-            function_name="test_func",
-            output_file="crash.jsonl",
-            clear_after_export=True,  # <--- Deletion requested, but
-            delete_only=False
-        )
-
-    # Assert
-    # 1. Check result
-    assert result["exported"] == 0
-    assert result["deleted"] == 0
-
-    # 2. CRITICAL: DB deletion must never be called
-    mock_archiver_deps["data"].delete_many.assert_not_called()
-
-
-def test_convert_to_training_format_logic(mock_archiver_deps):
-    """
-    Case 5: Test data format conversion logic (JSONL format)
-    """
-    archiver = VectorWaveArchiver()
-
-    # Mock Object Properties
-    valid_uuid = str(uuid.uuid4())
+def _seed(coll, *, function_name, return_value, status="SUCCESS", input_payload=None):
     props = {
-        "function_name": "calc",
-        "status": "SUCCESS",
-        "input_a": 10,       # Input value
-        "input_b": 20,       # Input value
-        "return_value": 30,  # Output value
-        "duration_ms": 100,  # Value to be excluded
-        "uuid": valid_uuid   # Value to be excluded (assuming inclusion in properties)
+        "function_uuid": str(uuid4()),
+        "function_name": function_name,
+        "return_value": return_value,
+        "status": status,
+        "duration_ms": 10,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
     }
-    mock_obj = create_mock_object(valid_uuid, props)
+    if input_payload:
+        props.update(input_payload)
+    return coll.data.insert(properties=props)
 
-    # Act
-    formatted = archiver._convert_to_training_format(mock_obj)
 
-    # Assert
-    assert "messages" in formatted
+def _read_jsonl(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Unit test — pure JSONL conversion, no DB needed
+# ---------------------------------------------------------------------------
+
+def test_convert_to_training_format_excludes_metadata_keys():
+    """`_convert_to_training_format` filters out internal fields and serializes inputs."""
+    from types import SimpleNamespace
+
+    obj = SimpleNamespace(
+        uuid=uuid4(),
+        properties={
+            "function_name": "calc",
+            "status": "SUCCESS",
+            "input_a": 10,
+            "input_b": 20,
+            "return_value": 30,
+            "duration_ms": 100,
+        },
+    )
+    formatted = VectorWaveArchiver.__new__(VectorWaveArchiver)._convert_to_training_format(obj)
+
     messages = formatted["messages"]
     assert len(messages) == 2
-
-    # Verify User Message (Input) - checking excluded keys are missing
     user_content = json.loads(messages[0]["content"])
     assert user_content == {"input_a": 10, "input_b": 20}
-    assert "status" not in user_content
-    assert "duration_ms" not in user_content
-    assert "uuid" not in user_content
-
-    # Verify Assistant Message (Output)
     assert messages[1]["content"] == "30"
+
+
+# ---------------------------------------------------------------------------
+# E2E — real Weaviate, real file IO
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_export_writes_jsonl_and_clears_when_requested(clean_weaviate, e2e_settings, tmp_path):
+    """export_and_clear with clear_after_export=True writes JSONL and removes the rows."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        _seed(coll, function_name="test_func", return_value="r1")
+        _seed(coll, function_name="test_func", return_value="r2")
+
+        out = tmp_path / "exports" / "dataset.jsonl"
+        archiver = VectorWaveArchiver()
+        result = archiver.export_and_clear(
+            function_name="test_func",
+            output_file=str(out),
+            clear_after_export=True,
+        )
+
+        assert result["exported"] == 2
+        assert result["deleted"] == 2
+
+        rows = _read_jsonl(out)
+        assert len(rows) == 2
+        assert all("messages" in r for r in rows)
+
+        remaining = coll.query.fetch_objects(limit=10).objects
+        assert len(remaining) == 0
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_export_only_does_not_delete(clean_weaviate, e2e_settings, tmp_path):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        _seed(coll, function_name="keep_me", return_value="r1")
+
+        out = tmp_path / "backup.jsonl"
+        archiver = VectorWaveArchiver()
+        result = archiver.export_and_clear(
+            function_name="keep_me",
+            output_file=str(out),
+            clear_after_export=False,
+        )
+
+        assert result["exported"] == 1
+        assert result["deleted"] == 0
+        assert len(coll.query.fetch_objects(limit=10).objects) == 1
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_delete_only_skips_file_and_purges(clean_weaviate, e2e_settings, tmp_path):
+    """delete_only mode purges all matching rows including non-SUCCESS ones."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        _seed(coll, function_name="purge_me", return_value="ok", status="SUCCESS")
+        _seed(coll, function_name="purge_me", return_value="bad", status="FAILURE")
+
+        out = tmp_path / "should_not_be_created.jsonl"
+        archiver = VectorWaveArchiver()
+        result = archiver.export_and_clear(
+            function_name="purge_me",
+            output_file=str(out),
+            delete_only=True,
+        )
+
+        assert result["exported"] == 0
+        assert result["deleted"] == 2
+        assert not out.exists()
+        assert len(coll.query.fetch_objects(limit=10).objects) == 0
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_file_write_failure_aborts_delete(clean_weaviate, e2e_settings, monkeypatch):
+    """If file write fails, no rows are deleted (safety invariant)."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        _seed(coll, function_name="safety", return_value="r1")
+
+        original_open = open
+
+        def failing_open(*args, **kwargs):
+            if args and args[0] and "safety_export.jsonl" in str(args[0]):
+                raise IOError("Disk Full")
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", failing_open)
+
+        archiver = VectorWaveArchiver()
+        result = archiver.export_and_clear(
+            function_name="safety",
+            output_file="safety_export.jsonl",
+            clear_after_export=True,
+        )
+
+        assert result["exported"] == 0
+        assert result["deleted"] == 0
+        assert len(coll.query.fetch_objects(limit=10).objects) == 1
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_export_only_includes_success_status(clean_weaviate, e2e_settings, tmp_path):
+    """Non-delete-only mode filters to status=SUCCESS rows for training export."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        _seed(coll, function_name="mixed", return_value="ok1", status="SUCCESS")
+        _seed(coll, function_name="mixed", return_value="ok2", status="SUCCESS")
+        _seed(coll, function_name="mixed", return_value="bad", status="FAILURE")
+
+        out = tmp_path / "training.jsonl"
+        archiver = VectorWaveArchiver()
+        result = archiver.export_and_clear(
+            function_name="mixed",
+            output_file=str(out),
+        )
+
+        assert result["exported"] == 2
+        rows = _read_jsonl(out)
+        assert len(rows) == 2
+    finally:
+        client.close()

--- a/src/tests/database/test_dataset.py
+++ b/src/tests/database/test_dataset.py
@@ -1,97 +1,166 @@
 import pytest
-from unittest.mock import MagicMock, patch
-import math
+from datetime import datetime, timezone
+
 from vectorwave.database.dataset import VectorWaveDatasetManager
+from vectorwave.database.db import (
+    get_weaviate_client,
+    create_execution_schema,
+    create_golden_dataset_schema,
+)
 from vectorwave.models.db_config import WeaviateSettings
 
+
 @pytest.fixture
-def mock_dataset_deps(monkeypatch):
-    """Mocking dependencies for DatasetManager tests"""
-    # 1. Settings Mock
-    mock_settings = WeaviateSettings(
-        EXECUTION_COLLECTION_NAME="Executions",
-        GOLDEN_COLLECTION_NAME="GoldenData",
-        RECOMMENDATION_STEADY_MARGIN=0.1,
-        RECOMMENDATION_DISCOVERY_MARGIN=0.2
+def e2e_settings() -> WeaviateSettings:
+    s = WeaviateSettings()
+    s.IS_VECTORIZE_COLLECTION_NAME = False
+    s.VECTORIZER = "none"
+    return s
+
+
+def _seed_execution(coll, *, function_name: str, return_value: str, vector, status="SUCCESS", uuid=None):
+    """Insert one execution log with an explicit vector. Returns the assigned uuid (str)."""
+    return coll.data.insert(
+        properties={
+            "function_name": function_name,
+            "function_uuid": "00000000-0000-0000-0000-000000000001",
+            "return_value": return_value,
+            "status": status,
+            "duration_ms": 10,
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        },
+        vector=vector,
+        uuid=uuid,
     )
-    mock_get_settings = MagicMock(return_value=mock_settings)
 
-    # 2. Client & Collections Mock
-    mock_client = MagicMock()
-    mock_exec_col = MagicMock()
-    mock_golden_col = MagicMock()
 
-    def get_collection_side_effect(name):
-        if name == "Executions": return mock_exec_col
-        if name == "GoldenData": return mock_golden_col
-        return MagicMock()
+@pytest.mark.e2e
+def test_register_as_golden_copies_vector_and_properties(clean_weaviate, e2e_settings):
+    """register_as_golden fetches the source log, copies its vector, and inserts into golden."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_golden_dataset_schema(client, e2e_settings)
+        exec_col = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        golden_col = client.collections.get(e2e_settings.GOLDEN_COLLECTION_NAME)
 
-    mock_client.collections.get.side_effect = get_collection_side_effect
-    mock_get_client = MagicMock(return_value=mock_client)
+        log_uuid = str(_seed_execution(
+            exec_col, function_name="calc", return_value="42", vector=[0.1, 0.2, 0.3]
+        ))
 
-    # 3. Patching
-    monkeypatch.setattr("vectorwave.database.dataset.get_cached_client", mock_get_client)
-    monkeypatch.setattr("vectorwave.database.dataset.get_weaviate_settings", mock_get_settings)
+        manager = VectorWaveDatasetManager()
+        assert manager.register_as_golden(log_uuid, note="Best case", tags=["benchmark"]) is True
 
-    return {
-        "exec_col": mock_exec_col,
-        "golden_col": mock_golden_col,
-        "settings": mock_settings
-    }
+        golden_objs = list(golden_col.iterator(include_vector=True))
+        assert len(golden_objs) == 1
+        g = golden_objs[0]
+        assert g.properties["original_uuid"] == log_uuid
+        assert g.properties["function_name"] == "calc"
+        assert g.properties["return_value"] == "42"
+        assert g.properties["note"] == "Best case"
+        assert g.properties["tags"] == ["benchmark"]
+        assert g.vector["default"] == pytest.approx([0.1, 0.2, 0.3])
+    finally:
+        client.close()
 
-def create_mock_obj(uuid_str, props=None, vector=None):
-    obj = MagicMock()
-    obj.uuid = uuid_str
-    obj.properties = props or {}
-    if vector:
-        obj.vector = {"default": vector}
-    return obj
 
-def test_register_as_golden_success(mock_dataset_deps):
-    """[Case 1] Test successful Golden Data registration"""
-    manager = VectorWaveDatasetManager()
+@pytest.mark.e2e
+def test_register_as_golden_fails_for_missing_log(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_golden_dataset_schema(client, e2e_settings)
 
-    # Arrange: Simulate successful retrieval of original log
-    mock_log = create_mock_obj("log-uuid-1", {"function_name": "test_func", "return_value": "res"}, vector=[0.1, 0.2])
-    mock_dataset_deps["exec_col"].query.fetch_object_by_id.return_value = mock_log
+        manager = VectorWaveDatasetManager()
+        assert manager.register_as_golden("00000000-0000-0000-0000-000000000999") is False
+    finally:
+        client.close()
 
-    # Act
-    result = manager.register_as_golden("log-uuid-1", note="Best case")
 
-    # Assert
-    assert result is True
-    # Verify if insert was called on Golden Collection
-    mock_dataset_deps["golden_col"].data.insert.assert_called_once()
-    call_kwargs = mock_dataset_deps["golden_col"].data.insert.call_args.kwargs
-    assert call_kwargs["properties"]["original_uuid"] == "log-uuid-1"
-    assert call_kwargs["properties"]["note"] == "Best case"
-    assert call_kwargs["vector"] == [0.1, 0.2] # Check if vector was copied
+@pytest.mark.e2e
+def test_register_as_golden_fails_when_log_has_no_vector(clean_weaviate, e2e_settings):
+    """A log inserted without a vector cannot be promoted (capture_return_value missing)."""
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_golden_dataset_schema(client, e2e_settings)
+        exec_col = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
 
-def test_recommend_candidates_logic(mock_dataset_deps):
-    """[Case 2] Test density-based recommendation logic (Steady/Discovery)"""
-    manager = VectorWaveDatasetManager()
+        log_uuid = str(exec_col.data.insert(
+            properties={
+                "function_name": "calc",
+                "function_uuid": "00000000-0000-0000-0000-000000000001",
+                "return_value": "42",
+                "status": "SUCCESS",
+                "duration_ms": 10,
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            },
+        ))
 
-    # Arrange 1: Golden Data (Set reference point)
-    # Centroid: [1.0, 1.0], Avg Dist: 0.0 (Assuming all points are identical)
-    golden_vec = [1.0, 1.0]
-    golden_objs = [create_mock_obj("gold-1", {"original_uuid": "origin-1"}, golden_vec)]
-    mock_dataset_deps["golden_col"].query.fetch_objects.return_value.objects = golden_objs
+        manager = VectorWaveDatasetManager()
+        assert manager.register_as_golden(log_uuid) is False
+    finally:
+        client.close()
 
-    # Cand A: [1.05, 1.05] -> Dist ≈ 0.07 (Steady Range: <= 0.1)
-    # Cand B: [1.2, 1.2]   -> Dist ≈ 0.28 (Discovery Range: 0.1 < d <= 0.3)
-    # Cand C: [2.0, 2.0]   -> Dist ≈ 1.41 (Ignore Range: > 0.3)
-    cand_a = create_mock_obj("cand-a", {"return_value": "A"}, [1.05, 1.05])
-    cand_b = create_mock_obj("cand-b", {"return_value": "B"}, [1.2, 1.2])
-    cand_c = create_mock_obj("cand-c", {"return_value": "C"}, [2.0, 2.0])
 
-    mock_dataset_deps["exec_col"].query.near_vector.return_value.objects = [cand_a, cand_b, cand_c]
+@pytest.mark.e2e
+def test_recommend_candidates_classifies_steady_and_discovery(clean_weaviate, e2e_settings, monkeypatch):
+    """Centroid math: candidates near the golden centroid are STEADY, slightly farther are DISCOVERY,
+    far ones are dropped.
+    """
+    from vectorwave.models.db_config import get_weaviate_settings
+    monkeypatch.setenv("RECOMMENDATION_STEADY_MARGIN", "0.1")
+    monkeypatch.setenv("RECOMMENDATION_DISCOVERY_MARGIN", "0.2")
+    get_weaviate_settings.cache_clear()
 
-    # Act
-    recommendations = manager.recommend_candidates("test_func")
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_golden_dataset_schema(client, e2e_settings)
+        exec_col = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        golden_col = client.collections.get(e2e_settings.GOLDEN_COLLECTION_NAME)
 
-    # Assert
-    assert len(recommendations) == 2
-    assert recommendations[0]["uuid"] == "cand-a"
-    assert recommendations[0]["type"] == "STEADY"
-    assert recommendations[1]["uuid"] == "cand-b"
-    assert recommendations[1]["type"] == "DISCOVERY"
+        # Single golden point at [1,1] -> centroid=[1,1], avg_dist=0
+        golden_col.data.insert(
+            properties={
+                "original_uuid": "origin-1",
+                "function_name": "test_func",
+                "return_value": "g",
+                "note": "",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "tags": [],
+            },
+            vector=[1.0, 1.0],
+        )
+
+        # Three candidates with controlled distances to the centroid
+        # cand_a: dist ≈ 0.071 (within steady_limit=0.1) -> STEADY
+        # cand_b: dist ≈ 0.283 (within discovery_limit=0.3, > 0.1) -> DISCOVERY
+        # cand_c: dist ≈ 1.414 (> discovery_limit) -> dropped
+        _seed_execution(exec_col, function_name="test_func", return_value="A", vector=[1.05, 1.05])
+        _seed_execution(exec_col, function_name="test_func", return_value="B", vector=[1.2, 1.2])
+        _seed_execution(exec_col, function_name="test_func", return_value="C", vector=[2.0, 2.0])
+
+        manager = VectorWaveDatasetManager()
+        recs = manager.recommend_candidates("test_func")
+
+        assert len(recs) == 2
+        types = {r["return_value"]: r["type"] for r in recs}
+        assert types["A"] == "STEADY"
+        assert types["B"] == "DISCOVERY"
+        assert "C" not in types
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_recommend_candidates_returns_empty_when_no_golden(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_golden_dataset_schema(client, e2e_settings)
+
+        manager = VectorWaveDatasetManager()
+        assert manager.recommend_candidates("nonexistent") == []
+    finally:
+        client.close()

--- a/src/tests/database/test_db.py
+++ b/src/tests/database/test_db.py
@@ -1,471 +1,212 @@
 import pytest
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch
 import weaviate
-import weaviate.classes.config as wvc
-# Import the specific driver exception to mock it
 from weaviate.exceptions import WeaviateConnectionError as WeaviateClientConnectionError
 
-# Import functions to be tested
-# (Assuming pytest is run from the project root and pytest.ini is set)
-from vectorwave.database.db import get_weaviate_client, create_vectorwave_schema
-from vectorwave.models.db_config import WeaviateSettings, get_weaviate_settings
+from vectorwave.database.db import (
+    get_weaviate_client,
+    create_vectorwave_schema,
+    create_execution_schema,
+)
+from vectorwave.models.db_config import WeaviateSettings
 from vectorwave.exception.exceptions import (
     WeaviateConnectionError,
     WeaviateNotReadyError,
-    SchemaCreationError
+    SchemaCreationError,
 )
 
-from vectorwave.database.db import create_execution_schema
 
-
-# --- Test Fixtures ---
+# ---------------------------------------------------------------------------
+# Unit tests — failure paths and pure config validation (no real Weaviate)
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
-def test_settings() -> WeaviateSettings:
-    """Returns a test Weaviate settings object."""
+def unit_settings() -> WeaviateSettings:
     return WeaviateSettings(
         WEAVIATE_HOST="test.host.local",
         WEAVIATE_PORT=1234,
         WEAVIATE_GRPC_PORT=5678,
         COLLECTION_NAME="TestCollection",
-        IS_VECTORIZE_COLLECTION_NAME=False
+        IS_VECTORIZE_COLLECTION_NAME=False,
     )
-
-# --- Tests for get_weaviate_client ---
-
-@patch('vectorwave.database.db.weaviate.connect_to_local')
-def test_get_weaviate_client_success(mock_connect_to_local, test_settings):
-    """
-    Case 1: Weaviate connection is successful.
-    - .connect_to_local() should be called.
-    - .is_ready() should return True.
-    - The created client object should be returned.
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_client.is_ready.return_value = True
-    mock_connect_to_local.return_value = mock_client
-
-    # 2. Act
-    client = get_weaviate_client(settings=test_settings)
-
-    # 3. Assert
-    # Check if 'connect_to_local' was called once with the correct args
-    mock_connect_to_local.assert_called_once_with(
-        host=test_settings.WEAVIATE_HOST,
-        port=test_settings.WEAVIATE_PORT,
-        grpc_port=test_settings.WEAVIATE_GRPC_PORT,
-        additional_config=ANY
-    )
-    mock_client.is_ready.assert_called_once()
-    assert client == mock_client
 
 
 @patch('vectorwave.database.db.weaviate.connect_to_local')
-def test_get_weaviate_client_connection_refused(mock_connect_to_local, test_settings):
-    """
-    Case 2: Connection is refused because Weaviate server is down.
-    - Should raise WeaviateConnectionError.
-    """
-    # 1. Arrange
-    # Mock the original Weaviate driver exception
+def test_get_weaviate_client_connection_refused(mock_connect_to_local, unit_settings):
+    """Connection refused at the driver level is wrapped as WeaviateConnectionError."""
     mock_connect_to_local.side_effect = WeaviateClientConnectionError("Connection refused")
-
-    # 2. Act & 3. Assert
     with pytest.raises(WeaviateConnectionError) as exc_info:
-        get_weaviate_client(settings=test_settings)
-
-    # Check if the error message from the original exception is included
+        get_weaviate_client(settings=unit_settings)
     assert "Connection refused" in str(exc_info.value)
     assert "Failed to connect to Weaviate" in str(exc_info.value)
 
 
 @patch('vectorwave.database.db.weaviate.connect_to_local')
-def test_get_weaviate_client_not_ready(mock_connect_to_local, test_settings):
-    """
-    Case 3: Connected, but Weaviate is not ready (.is_ready() returns False).
-    - Should raise WeaviateNotReadyError.
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_client.is_ready.return_value = False # This is the trigger
+def test_get_weaviate_client_not_ready(mock_connect_to_local, unit_settings):
+    """A connected-but-not-ready client raises WeaviateNotReadyError."""
+    mock_client = MagicMock()
+    mock_client.is_ready.return_value = False
     mock_connect_to_local.return_value = mock_client
-
-    # 2. Act & 3. Assert
     with pytest.raises(WeaviateNotReadyError) as exc_info:
-        get_weaviate_client(settings=test_settings)
-
+        get_weaviate_client(settings=unit_settings)
     assert "server is not ready" in str(exc_info.value)
 
 
-# --- Tests for create_vectorwave_schema ---
-
-def test_create_schema_new(test_settings):
-    """
-    Case 4: Schema doesn't exist and is created successfully.
-    - .collections.exists() returns False.
-    - .collections.create() should be called.
-    - .collections.get() should not be called.
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False # Trigger for creation
-    mock_new_collection = MagicMock()
-    mock_collections.create.return_value = mock_new_collection
-    mock_client.collections = mock_collections
-
-    # 2. Act
-    collection = create_vectorwave_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.exists.assert_called_once_with(test_settings.COLLECTION_NAME)
-    mock_collections.create.assert_called_once()
-
-    # Check if 'create' was called with the correct 'name'
-    call_args = mock_collections.create.call_args
-    assert call_args.kwargs.get('name') == test_settings.COLLECTION_NAME
-
-    # Check if key properties were passed
-    passed_props = [prop.name for prop in call_args.kwargs.get('properties', [])]
-    assert "function_name" in passed_props
-    assert "source_code" in passed_props
-
-    mock_collections.get.assert_not_called()
-    assert collection == mock_new_collection
-
-
-def test_create_schema_existing(test_settings):
-    """
-    Case 5: Schema already exists.
-    - .collections.exists() returns True.
-    - .collections.create() should not be called.
-    - .collections.get() should be called.
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = True # Trigger for skipping
-    mock_existing_collection = MagicMock()
-    mock_collections.get.return_value = mock_existing_collection
-    mock_client.collections = mock_collections
-
-    # 2. Act
-    collection = create_vectorwave_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.exists.assert_called_once_with(test_settings.COLLECTION_NAME)
-    mock_collections.create.assert_not_called()
-    mock_collections.get.assert_called_once_with(test_settings.COLLECTION_NAME)
-    assert collection == mock_existing_collection
-
-
-def test_create_schema_creation_error(test_settings):
-    """
-    Case 6: An error occurs during schema creation (e.g., bad API key).
-    - Should raise SchemaCreationError.
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    # Set .create() to raise an exception
-    mock_collections.create.side_effect = Exception("Invalid OpenAI API Key")
-    mock_client.collections = mock_collections
-
-    # 2. Act & 3. Assert
+def test_create_schema_creation_error_is_wrapped(unit_settings):
+    """An exception from client.collections.create surfaces as SchemaCreationError."""
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
+    mock_client.collections.create.side_effect = Exception("Invalid OpenAI API Key")
     with pytest.raises(SchemaCreationError) as exc_info:
-        create_vectorwave_schema(mock_client, test_settings)
-
+        create_vectorwave_schema(mock_client, unit_settings)
     assert "Error creating collection" in str(exc_info.value)
     assert "Invalid OpenAI API Key" in str(exc_info.value)
 
 
-@pytest.fixture
-def settings_with_custom_props() -> WeaviateSettings:
-    """
-    Returns a WeaviateSettings object assuming 'get_weaviate_settings'
-    successfully loaded the JSON.
-    """
-    settings = WeaviateSettings(
-        COLLECTION_NAME="TestCollection",
-        IS_VECTORIZE_COLLECTION_NAME=False
-    )
-    # Manually inject the loaded data into the custom_properties field
-    settings.custom_properties = {
-        "run_id": {
-            "data_type": "TEXT",
-            "description": "The ID of the specific test run"
-        },
-        "experiment_id": {
-            "data_type": "INT",
-            "description": "Identifier for the experiment"
-        }
-    }
-    return settings
-
-@pytest.fixture
-def settings_with_invalid_type_prop() -> WeaviateSettings:
-    """Returns settings with an invalid string in 'data_type'."""
+def test_create_schema_custom_prop_invalid_data_type():
+    """Invalid `data_type` in custom_properties raises SchemaCreationError before any DB call."""
     settings = WeaviateSettings(COLLECTION_NAME="TestCollection")
     settings.custom_properties = {
-        "bad_prop": {
-            "data_type": "INVALID_WEAVIATE_TYPE", # <-- Invalid type
-            "description": "This should fail"
-        }
+        "bad_prop": {"data_type": "INVALID_WEAVIATE_TYPE", "description": "x"}
     }
-    return settings
-
-@pytest.fixture
-def settings_with_missing_type_prop() -> WeaviateSettings:
-    """Returns settings where the 'data_type' key itself is missing."""
-    settings = WeaviateSettings(COLLECTION_NAME="TestCollection")
-    settings.custom_properties = {
-        "another_bad_prop": {
-            "description": "data_type key is missing" # <-- data_type missing
-        }
-    }
-    return settings
-
-
-
-# [New] Test Cases for Issue #11: Custom Property *Parsing*
-
-def test_create_schema_with_custom_properties(settings_with_custom_props):
-    """
-    Case 7: Test if custom properties (run_id, experiment_id) are correctly added to the schema
-    - .collections.create() should be called with the correct 'properties' argument
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False # Trigger creation
-    mock_new_collection = MagicMock()
-    mock_collections.create.return_value = mock_new_collection
-    mock_client.collections = mock_collections
-
-    # 2. Act
-    # Use the 'settings_with_custom_props' fixture
-    create_vectorwave_schema(mock_client, settings_with_custom_props)
-
-    # 3. Assert
-    # Check if create was called
-    mock_collections.create.assert_called_once()
-
-    # Check the arguments (kwargs) passed to create
-    call_args = mock_collections.create.call_args
-    passed_props_list = call_args.kwargs.get('properties', [])
-
-    # For convenience, convert the list to a map by name
-    passed_props_map = {prop.name: prop for prop in passed_props_list}
-
-    # Check if base properties still exist
-    assert "function_name" in passed_props_map
-    assert "source_code" in passed_props_map
-    assert passed_props_map["function_name"].dataType == wvc.DataType.TEXT
-
-    assert "search_description" in passed_props_map
-    assert "sequence_narrative" in passed_props_map
-
-    # --- Custom Property Validation ---
-    assert "run_id" in passed_props_map
-    assert "experiment_id" in passed_props_map
-
-
-    # Validate 'run_id' type and description
-    run_id_prop = passed_props_map["run_id"]
-    assert run_id_prop.dataType == wvc.DataType.TEXT
-    assert run_id_prop.description == "The ID of the specific test run"
-
-    # Validate 'experiment_id' type and description
-    exp_id_prop = passed_props_map["experiment_id"]
-    assert exp_id_prop.dataType == wvc.DataType.INT
-    assert exp_id_prop.description == "Identifier for the experiment"
-
-
-    # Check total property count (7 base + 2 custom)
-    assert len(passed_props_list) == 7 + 2
-
-
-def test_create_schema_custom_prop_invalid_type(settings_with_invalid_type_prop):
-    """
-    Case 8: Test if SchemaCreationError is raised when 'data_type' has an invalid value
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    mock_client.collections = mock_collections
-
-    # 2. Act & 3. Assert
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
     with pytest.raises(SchemaCreationError) as exc_info:
-        create_vectorwave_schema(mock_client, settings_with_invalid_type_prop)
-
-    # Check if the error message includes the invalid type name
+        create_vectorwave_schema(mock_client, settings)
     assert "Invalid data_type 'INVALID_WEAVIATE_TYPE'" in str(exc_info.value)
     assert "bad_prop" in str(exc_info.value)
 
 
-def test_create_schema_custom_prop_missing_type(settings_with_missing_type_prop):
-    """
-    Case 9: Test if SchemaCreationError is raised when the 'data_type' key is missing
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    mock_client.collections = mock_collections
-
-    # 2. Act & 3. Assert
+def test_create_schema_custom_prop_missing_data_type():
+    """A custom_properties entry without `data_type` raises SchemaCreationError."""
+    settings = WeaviateSettings(COLLECTION_NAME="TestCollection")
+    settings.custom_properties = {
+        "another_bad_prop": {"description": "data_type key is missing"}
+    }
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
     with pytest.raises(SchemaCreationError) as exc_info:
-        create_vectorwave_schema(mock_client, settings_with_missing_type_prop)
-
-    # Check if the error message indicates 'data_type' is missing
+        create_vectorwave_schema(mock_client, settings)
     assert "missing 'data_type'" in str(exc_info.value)
     assert "another_bad_prop" in str(exc_info.value)
 
 
-@patch('vectorwave.database.db.wvc.Configure.Vectorizer.none')
-def test_create_execution_schema_new(mock_vectorizer_none, test_settings):
-    """
-    Case 10: Test if 'VectorWaveExecutions' schema is created successfully when it does not exist
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False # 생성 트리거
-    mock_new_collection = MagicMock()
-    mock_collections.create.return_value = mock_new_collection
-    mock_client.collections = mock_collections
-
-    # 2. Act
-    collection = create_execution_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.exists.assert_called_once_with(test_settings.EXECUTION_COLLECTION_NAME)
-    mock_collections.create.assert_called_once()
-
-    call_args = mock_collections.create.call_args
-    assert call_args.kwargs.get('name') == test_settings.EXECUTION_COLLECTION_NAME
-
-    # Check if base properties are included
-    passed_props_map = {prop.name: prop for prop in call_args.kwargs.get('properties', [])}
-    assert "function_uuid" in passed_props_map
-    assert "timestamp_utc" in passed_props_map
-    assert "status" in passed_props_map
-    assert "duration_ms" in passed_props_map
-
-    assert "return_value" in passed_props_map
-    assert passed_props_map["return_value"].dataType == wvc.DataType.TEXT
-
-    assert collection == mock_new_collection
-
-
-def test_create_execution_schema_existing(test_settings):
-    """
-    Case 11: Test if creation is skipped when 'VectorWaveExecutions' schema already exists
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = True
-    mock_existing_collection = MagicMock()
-    mock_collections.get.return_value = mock_existing_collection
-    mock_client.collections = mock_collections
-
-    # 2. Act
-    collection = create_execution_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.exists.assert_called_once_with(test_settings.EXECUTION_COLLECTION_NAME)
-    mock_collections.create.assert_not_called() # create should not be called
-    mock_collections.get.assert_called_once_with(test_settings.EXECUTION_COLLECTION_NAME) # get should be called
-    assert collection == mock_existing_collection
-
-
-
-
-def test_create_schema_vectorizer_openai(test_settings):
-    """
-    Case 12: Test if the correct dict config is passed when VECTORIZER_CONFIG='text2vec-openai'
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    mock_client.collections = mock_collections
-
-    test_settings.VECTORIZER = "weaviate_module"
-    test_settings.WEAVIATE_VECTORIZER_MODULE = "text2vec-openai"
-
-    # [수정] test_settings.GENERATIVE_CONFIG = "generative-openai" ->
-    test_settings.WEAVIATE_GENERATIVE_MODULE = "generative-openai"
-
-
-    # 2. Act
-    create_vectorwave_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.create.assert_called_once()
-
-    call_args = mock_collections.create.call_args
-
-    vector_config_arg = call_args.kwargs.get('vectorizer_config')
-    # assert isinstance(vector_config_arg, wvc.Configure.Vectorizer)
-    # assert vector_config_arg.name == "text2vec-openai"
-
-    assert vector_config_arg.vectorizer == "text2vec-openai"
-
-    # 3b. Generative Config 검증
-    generative_config_arg = call_args.kwargs.get('generative_config')
-    assert generative_config_arg.generative == "generative-openai"
-
-
-
-
-def test_create_schema_vectorizer_none(test_settings):
-    """
-    Case 13: Test if the correct dict config is passed when VECTORIZER_CONFIG='none'
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    mock_client.collections = mock_collections
-
-    test_settings.VECTORIZER = "none"
-    test_settings.WEAVIATE_VECTORIZER_MODULE = ""
-
-    # 2. Act
-    create_vectorwave_schema(mock_client, test_settings)
-
-    # 3. Assert
-    mock_collections.create.assert_called_once()
-
-    call_args = mock_collections.create.call_args
-    # mock_none.assert_called_once() -> 삭제
-
-    vector_config_arg = call_args.kwargs.get('vectorizer_config')
-
-
-    assert vector_config_arg.vectorizer == "none"
-
-
-def test_create_schema_vectorizer_invalid(test_settings):
-    """
-    Case 14: Test if SchemaCreationError is raised for an unsupported VECTORIZER_CONFIG value
-    """
-    # 1. Arrange
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections = MagicMock()
-    mock_collections.exists.return_value = False
-    mock_client.collections = mock_collections
-
-    test_settings.VECTORIZER = "unsupported-module"
-
-    # 2. Act & 3. Assert
+def test_create_schema_invalid_vectorizer_setting(unit_settings):
+    """An unsupported VECTORIZER value raises SchemaCreationError."""
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = False
+    unit_settings.VECTORIZER = "unsupported-module"
     with pytest.raises(SchemaCreationError) as exc_info:
-        create_vectorwave_schema(mock_client, test_settings)
-
+        create_vectorwave_schema(mock_client, unit_settings)
     assert "Invalid VECTORIZER setting" in str(exc_info.value)
     assert "unsupported-module" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# E2E tests — exercise real Weaviate via the testcontainer fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def e2e_settings() -> WeaviateSettings:
+    """Settings pointing at the testcontainer (host/port from env)."""
+    s = WeaviateSettings()
+    s.IS_VECTORIZE_COLLECTION_NAME = False
+    s.VECTORIZER = "none"
+    return s
+
+
+@pytest.mark.e2e
+def test_get_weaviate_client_success(weaviate_container):
+    client = get_weaviate_client()
+    try:
+        assert client.is_ready()
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_create_vectorwave_schema_creates_expected_properties(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.COLLECTION_NAME)
+        prop_names = {p.name for p in coll.config.get().properties}
+        assert {"function_name", "source_code", "search_description", "sequence_narrative"} <= prop_names
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_create_vectorwave_schema_is_idempotent(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        create_vectorwave_schema(client, e2e_settings)
+        assert client.collections.exists(e2e_settings.COLLECTION_NAME)
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_create_vectorwave_schema_with_custom_properties(clean_weaviate, e2e_settings):
+    e2e_settings.custom_properties = {
+        "run_id": {"data_type": "TEXT", "description": "The ID of the specific test run"},
+        "experiment_id": {"data_type": "INT", "description": "Identifier for the experiment"},
+    }
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.COLLECTION_NAME)
+        props = {p.name for p in coll.config.get().properties}
+        assert "run_id" in props
+        assert "experiment_id" in props
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_create_execution_schema_creates_expected_properties(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.EXECUTION_COLLECTION_NAME)
+        prop_names = {p.name for p in coll.config.get().properties}
+        assert {"function_uuid", "timestamp_utc", "status", "duration_ms", "return_value"} <= prop_names
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_create_execution_schema_is_idempotent(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        create_execution_schema(client, e2e_settings)
+        assert client.collections.exists(e2e_settings.EXECUTION_COLLECTION_NAME)
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_schema_accepts_text2vec_openai_config(clean_weaviate, e2e_settings):
+    """Weaviate accepts the text2vec-openai vectorizer + generative-openai config we build."""
+    e2e_settings.VECTORIZER = "weaviate_module"
+    e2e_settings.WEAVIATE_VECTORIZER_MODULE = "text2vec-openai"
+    e2e_settings.WEAVIATE_GENERATIVE_MODULE = "generative-openai"
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        assert client.collections.exists(e2e_settings.COLLECTION_NAME)
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_schema_accepts_vectorizer_none(clean_weaviate, e2e_settings):
+    e2e_settings.VECTORIZER = "none"
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        assert client.collections.exists(e2e_settings.COLLECTION_NAME)
+    finally:
+        client.close()

--- a/src/tests/database/test_db_search.py
+++ b/src/tests/database/test_db_search.py
@@ -1,163 +1,222 @@
 import pytest
-from unittest.mock import patch, MagicMock, ANY
-import weaviate.classes as wvc
-import weaviate
+from datetime import datetime, timezone
+from uuid import uuid4
 
-# Functions to test
 from vectorwave.database.db_search import (
     search_functions,
     search_executions,
-    _build_weaviate_filters
+    _build_weaviate_filters,
+)
+from vectorwave.database.db import (
+    get_weaviate_client,
+    create_vectorwave_schema,
+    create_execution_schema,
 )
 from vectorwave.models.db_config import WeaviateSettings
 
 
-@pytest.fixture
-def mock_search_deps(monkeypatch):
-    """ Mock dependencies for search_functions (mocking near_text method) """
-    mock_settings = WeaviateSettings(COLLECTION_NAME="TestFunctions")
-    mock_get_settings = MagicMock(return_value=mock_settings)
-    monkeypatch.setattr("vectorwave.database.db_search.get_weaviate_settings", mock_get_settings)
-
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections_obj = MagicMock()
-    mock_func_collection = MagicMock()
-
-    mock_query_obj = MagicMock()
-    mock_obj = MagicMock()
-    mock_obj.properties = {"name": "test_func"}
-    mock_obj.metadata = MagicMock(uuid="test-uuid")
-    mock_query_obj.near_text.return_value = MagicMock(objects=[mock_obj])
-
-    mock_func_collection.query = mock_query_obj
-
-    def get_collection_side_effect(name):
-        if name == "TestFunctions":
-            return mock_func_collection
-        return MagicMock()
-
-    mock_collections_obj.get = MagicMock(side_effect=get_collection_side_effect)
-    mock_client.collections = mock_collections_obj
-
-    mock_get_client = MagicMock(return_value=mock_client)
-    monkeypatch.setattr("vectorwave.database.db_search.get_cached_client", mock_get_client)
-
-    return {
-        "client": mock_client,
-        "collection": mock_func_collection,
-        "query": mock_query_obj, # Return query object for testing
-        "settings": mock_settings
-    }
-
-# --- Test _build_weaviate_filters helper function ---
+# ---------------------------------------------------------------------------
+# Unit tests — pure filter-builder logic (no Weaviate involved)
+# ---------------------------------------------------------------------------
 
 def test_build_filters_none_or_empty():
     assert _build_weaviate_filters(None) is None
     assert _build_weaviate_filters({}) is None
 
-def test_build_filters_single():
-    filters = {"team": "billing"}
-    result = _build_weaviate_filters(filters)
-    # [MODIFIED] isinstance -> is not None (Fix AssertionError)
-    assert result is not None
 
-def test_build_filters_multiple():
-    filters = {"team": "billing", "priority": 1}
-    result = _build_weaviate_filters(filters)
-    # [MODIFIED] isinstance -> is not None (Fix AssertionError)
-    assert result is not None
+def test_build_filters_single_property():
+    assert _build_weaviate_filters({"team": "billing"}) is not None
 
 
-# --- Basic tests for search_functions ---
-
-def test_search_functions_basic_call(mock_search_deps):
-    # [MODIFIED] Test the near_text method instead of fetch_objects.
-    mock_query = mock_search_deps["query"]
-    search_functions(query="test query", limit=3)
-
-    mock_query.near_text.assert_called_once_with(
-        query="test query",
-        limit=3,
-        filters=None,
-        return_metadata=wvc.query.MetadataQuery(distance=True)
-    )
-
-def test_search_functions_with_filters(mock_search_deps):
-    mock_query = mock_search_deps["query"]
-    test_filters = {"team": "billing"}
-
-    search_functions(query="filtered query", limit=5, filters=test_filters)
-
-    mock_query.near_text.assert_called_once()
-    call_args = mock_query.near_text.call_args
-
-    assert call_args.kwargs['query'] == "filtered query"
-    assert call_args.kwargs['limit'] == 5
-    assert call_args.kwargs['filters'] is not None
+def test_build_filters_multiple_properties():
+    assert _build_weaviate_filters({"team": "billing", "priority": 1}) is not None
 
 
-# --- Tests for search_executions ---
+def test_build_filters_supports_operators():
+    """Operators encoded in the key (e.g. duration_ms__gte) build without error."""
+    assert _build_weaviate_filters({"duration_ms__gte": 100}) is not None
+    assert _build_weaviate_filters({"status__not_equal": "FAILURE"}) is not None
+    assert _build_weaviate_filters({"function_name__like": "foo"}) is not None
+
+
+# ---------------------------------------------------------------------------
+# E2E fixtures
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
-def mock_search_exec_deps(monkeypatch):
-    """ Mock dependencies for search_executions (no change) """
-    mock_settings = WeaviateSettings(EXECUTION_COLLECTION_NAME="TestExecutions")
-    mock_get_settings = MagicMock(return_value=mock_settings)
-    monkeypatch.setattr("vectorwave.database.db_search.get_weaviate_settings", mock_get_settings)
+def e2e_settings() -> WeaviateSettings:
+    s = WeaviateSettings()
+    s.IS_VECTORIZE_COLLECTION_NAME = False
+    s.VECTORIZER = "none"
+    return s
 
-    mock_client = MagicMock(spec=weaviate.WeaviateClient)
-    mock_collections_obj = MagicMock()
-    mock_exec_collection = MagicMock()
-    mock_exec_collection.query.fetch_objects.return_value = MagicMock(objects=[])
 
-    def get_collection_side_effect(name):
-        if name == "TestExecutions":
-            return mock_exec_collection
-        return MagicMock()
+@pytest.fixture
+def hf_vectorizer_env(monkeypatch):
+    """Switch the process to the local HuggingFace vectorizer for search-by-text tests.
 
-    mock_collections_obj.get = MagicMock(side_effect=get_collection_side_effect)
-    mock_client.collections = mock_collections_obj
+    This avoids any dependency on OpenAI keys: embeddings are computed locally with
+    sentence-transformers, then passed to Weaviate's near_vector path.
+    """
+    from vectorwave.models.db_config import get_weaviate_settings
+    from vectorwave.vectorizer.factory import get_vectorizer
 
-    mock_get_client = MagicMock(return_value=mock_client)
-    monkeypatch.setattr("vectorwave.database.db_search.get_cached_client", mock_get_client)
+    monkeypatch.setenv("VECTORIZER", "huggingface")
+    get_weaviate_settings.cache_clear()
+    get_vectorizer.cache_clear()
+    try:
+        yield
+    finally:
+        monkeypatch.setenv("VECTORIZER", "none")
+        get_weaviate_settings.cache_clear()
+        get_vectorizer.cache_clear()
 
-    return {
-        "client": mock_client,
-        "collection": mock_exec_collection,
-        "settings": mock_settings
+
+def _seed_executions(client, settings, rows):
+    """Insert (function_name, status, duration_ms) rows into the executions collection."""
+    coll = client.collections.get(settings.EXECUTION_COLLECTION_NAME)
+    for r in rows:
+        coll.data.insert(properties={
+            "function_uuid": str(uuid4()),
+            "function_name": r["function_name"],
+            "status": r["status"],
+            "duration_ms": r["duration_ms"],
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        })
+
+
+# ---------------------------------------------------------------------------
+# E2E — search_executions (no vectorizer needed; uses fetch_objects)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_search_executions_filter_by_status(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        _seed_executions(client, e2e_settings, [
+            {"function_name": "a", "status": "SUCCESS", "duration_ms": 100},
+            {"function_name": "b", "status": "FAILURE", "duration_ms": 50},
+            {"function_name": "c", "status": "SUCCESS", "duration_ms": 200},
+        ])
+
+        all_rows = search_executions(limit=10)
+        assert len(all_rows) == 3
+
+        success_only = search_executions(limit=10, filters={"status": "SUCCESS"})
+        assert len(success_only) == 2
+        assert all(r["status"] == "SUCCESS" for r in success_only)
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_search_executions_sort_by_duration_descending(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        _seed_executions(client, e2e_settings, [
+            {"function_name": "a", "status": "SUCCESS", "duration_ms": 50},
+            {"function_name": "b", "status": "SUCCESS", "duration_ms": 200},
+            {"function_name": "c", "status": "SUCCESS", "duration_ms": 100},
+        ])
+
+        results = search_executions(limit=10, sort_by="duration_ms", sort_ascending=False)
+        durations = [r["duration_ms"] for r in results]
+        assert durations == sorted(durations, reverse=True)
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_search_executions_limit_is_respected(clean_weaviate, e2e_settings):
+    client = get_weaviate_client()
+    try:
+        create_execution_schema(client, e2e_settings)
+        _seed_executions(client, e2e_settings, [
+            {"function_name": f"f{i}", "status": "SUCCESS", "duration_ms": i}
+            for i in range(5)
+        ])
+
+        results = search_executions(limit=2)
+        assert len(results) == 2
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# E2E — search_functions (uses HuggingFace vectorizer for near_vector path)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.e2e
+def test_search_functions_returns_semantically_closest_match(
+    clean_weaviate, e2e_settings, hf_vectorizer_env
+):
+    """Seed two semantically distinct functions, verify the closer one ranks first."""
+    from vectorwave.vectorizer.factory import get_vectorizer
+
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.COLLECTION_NAME)
+        vectorizer = get_vectorizer()
+        assert vectorizer is not None
+
+        text_a = "calculate the total price including sales tax for an order"
+        text_b = "render a react component into the dom tree"
+        coll.data.insert(
+            properties={
+                "function_name": "calc_tax",
+                "source_code": text_a,
+                "search_description": text_a,
+            },
+            vector=vectorizer.embed(text_a),
+        )
+        coll.data.insert(
+            properties={
+                "function_name": "render_dom",
+                "source_code": text_b,
+                "search_description": text_b,
+            },
+            vector=vectorizer.embed(text_b),
+        )
+
+        results = search_functions(query="how do I compute sales tax?", limit=2)
+        assert len(results) >= 1
+        assert results[0]["properties"]["function_name"] == "calc_tax"
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_search_functions_respects_filter(clean_weaviate, e2e_settings, hf_vectorizer_env):
+    """Filter narrows the result set to entries matching the property."""
+    from vectorwave.vectorizer.factory import get_vectorizer
+
+    e2e_settings.custom_properties = {
+        "team": {"data_type": "TEXT", "description": "team owner"},
     }
 
-def test_search_executions_default_sort(mock_search_exec_deps):
-    mock_collection = mock_search_exec_deps["collection"]
-    search_executions(limit=5)
+    client = get_weaviate_client()
+    try:
+        create_vectorwave_schema(client, e2e_settings)
+        coll = client.collections.get(e2e_settings.COLLECTION_NAME)
+        vectorizer = get_vectorizer()
 
-    mock_collection.query.fetch_objects.assert_called_once_with(
-        limit=5,
-        filters=None,
-        sort=ANY
-    )
+        for name, team in [("billing_calc", "billing"), ("auth_check", "auth")]:
+            text = f"function for {team}"
+            coll.data.insert(
+                properties={
+                    "function_name": name,
+                    "source_code": text,
+                    "search_description": text,
+                    "team": team,
+                },
+                vector=vectorizer.embed(text),
+            )
 
-    call_args = mock_collection.query.fetch_objects.call_args
-    sort_arg = call_args.kwargs['sort']
-
-    assert sort_arg is not None
-
-def test_search_executions_filter_and_sort_duration(mock_search_exec_deps):
-    mock_collection = mock_search_exec_deps["collection"]
-    test_filters = {"status": "SUCCESS"}
-
-    search_executions(
-        limit=3,
-        filters=test_filters,
-        sort_by="duration_ms",
-        sort_ascending=False
-    )
-
-    mock_collection.query.fetch_objects.assert_called_once()
-    call_args = mock_collection.query.fetch_objects.call_args
-
-    assert call_args.kwargs['limit'] == 3
-    assert call_args.kwargs['filters'] is not None
-
-    sort_arg = call_args.kwargs['sort']
-    assert sort_arg is not None
+        results = search_functions(query="anything", limit=10, filters={"team": "billing"})
+        assert len(results) == 1
+        assert results[0]["properties"]["function_name"] == "billing_calc"
+    finally:
+        client.close()

--- a/src/tests/test_e2e_fixture.py
+++ b/src/tests/test_e2e_fixture.py
@@ -1,0 +1,48 @@
+"""Smoke test for the testcontainers-backed weaviate_container fixture.
+
+Verifies that the session-scoped fixture spins up a real Weaviate instance,
+the connection helpers pick up the dynamic host/port via env vars, and the
+clean_weaviate fixture wipes collections between tests.
+"""
+import pytest
+
+
+@pytest.mark.e2e
+def test_weaviate_container_is_reachable(weaviate_container):
+    from vectorwave.database.db import get_weaviate_client
+
+    client = get_weaviate_client()
+    try:
+        assert client.is_ready()
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_clean_weaviate_creates_and_wipes(clean_weaviate):
+    from vectorwave.database.db import get_weaviate_client
+    import weaviate.classes.config as wvc
+
+    client = get_weaviate_client()
+    try:
+        client.collections.create(
+            name="VectorWaveFunctions",
+            properties=[wvc.Property(name="dummy", data_type=wvc.DataType.TEXT)],
+            vectorizer_config=wvc.Configure.Vectorizer.none(),
+        )
+        assert client.collections.exists("VectorWaveFunctions")
+    finally:
+        client.close()
+
+
+@pytest.mark.e2e
+def test_clean_weaviate_isolates_between_tests(clean_weaviate):
+    from vectorwave.database.db import get_weaviate_client
+
+    client = get_weaviate_client()
+    try:
+        assert not client.collections.exists("VectorWaveFunctions"), (
+            "previous test's collection leaked — clean_weaviate teardown failed"
+        )
+    finally:
+        client.close()

--- a/src/vectorwave/cli/__init__.py
+++ b/src/vectorwave/cli/__init__.py
@@ -1,0 +1,147 @@
+"""VectorWave CLI entry point.
+
+`vectorwave dev` manages a local Weaviate instance for running test_ex/ scripts
+end-to-end without manually wiring docker-compose, env vars, and the Rust build.
+"""
+import argparse
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from importlib import resources
+from pathlib import Path
+
+PROJECT_NAME = "vectorwave-dev"
+WEAVIATE_READY_URL = "http://localhost:8080/v1/.well-known/ready"
+WEAVIATE_READY_TIMEOUT_S = 60
+
+
+def _compose_path() -> Path:
+    return resources.files("vectorwave.cli.dev").joinpath("compose.yml")
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(
+        ["docker", "info"], capture_output=True
+    ).returncode == 0
+
+
+def _compose(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", "compose", "-p", PROJECT_NAME, "-f", str(_compose_path()), *args],
+        check=check,
+    )
+
+
+def _wait_until_ready(timeout: int = WEAVIATE_READY_TIMEOUT_S) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(WEAVIATE_READY_URL, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, ConnectionError, TimeoutError):
+            pass
+        time.sleep(1)
+    return False
+
+
+def _maturin_build_warning() -> None:
+    try:
+        import vectorwave.vectorwave_core  # noqa: F401
+    except ImportError:
+        print(
+            "[warn] Rust extension not compiled. Run 'maturin develop' to enable "
+            "the high-performance batch path (Python fallback will be used until then).",
+            file=sys.stderr,
+        )
+
+
+def cmd_start(_args: argparse.Namespace) -> int:
+    if not _docker_available():
+        print("[error] Docker is not available. Install/start Docker first.", file=sys.stderr)
+        return 1
+    print(f"[start] bringing up '{PROJECT_NAME}' stack")
+    rc = _compose("up", "-d").returncode
+    if rc != 0:
+        return rc
+    print("[start] waiting for Weaviate to be ready...")
+    if not _wait_until_ready():
+        print("[error] Weaviate did not become ready in time. Check 'vectorwave dev logs'.", file=sys.stderr)
+        return 1
+    _maturin_build_warning()
+    print("\n  Weaviate : http://localhost:8080")
+    print("  gRPC     : localhost:50051")
+    print("  Console  : http://localhost:8081\n")
+    print("Set in your .env (or shell) to point scripts at this instance:")
+    print("  WEAVIATE_HOST=localhost")
+    print("  WEAVIATE_PORT=8080")
+    print("  WEAVIATE_GRPC_PORT=50051")
+    return 0
+
+
+def cmd_stop(_args: argparse.Namespace) -> int:
+    return _compose("down").returncode
+
+
+def cmd_reset(_args: argparse.Namespace) -> int:
+    rc = _compose("down", "-v").returncode
+    if rc != 0:
+        return rc
+    return cmd_start(_args)
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    rc = _compose("ps").returncode
+    try:
+        with urllib.request.urlopen(WEAVIATE_READY_URL, timeout=2) as resp:
+            print(f"weaviate ready endpoint: HTTP {resp.status}")
+    except Exception as e:
+        print(f"weaviate ready endpoint: unreachable ({e})")
+    return rc
+
+
+def cmd_logs(args: argparse.Namespace) -> int:
+    compose_args = ["logs"]
+    if args.follow:
+        compose_args.append("-f")
+    else:
+        compose_args.extend(["--tail", str(args.tail)])
+    if args.service:
+        compose_args.append(args.service)
+    return _compose(*compose_args).returncode
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vectorwave")
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+
+    dev = subparsers.add_parser("dev", help="Manage the local e2e dev environment")
+    dev_sub = dev.add_subparsers(dest="dev_cmd", required=True)
+
+    dev_sub.add_parser("start", help="Start Weaviate + console").set_defaults(func=cmd_start)
+    dev_sub.add_parser("stop", help="Stop the dev stack").set_defaults(func=cmd_stop)
+    dev_sub.add_parser("reset", help="Wipe data volumes and restart").set_defaults(func=cmd_reset)
+    dev_sub.add_parser("status", help="Show stack status").set_defaults(func=cmd_status)
+
+    logs = dev_sub.add_parser("logs", help="Tail container logs")
+    logs.add_argument("service", nargs="?", default=None, help="Service name (default: all)")
+    logs.add_argument("-f", "--follow", action="store_true")
+    logs.add_argument("-n", "--tail", type=int, default=100)
+    logs.set_defaults(func=cmd_logs)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vectorwave/cli/__main__.py
+++ b/src/vectorwave/cli/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from vectorwave.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vectorwave/cli/dev/compose.yml
+++ b/src/vectorwave/cli/dev/compose.yml
@@ -1,0 +1,33 @@
+services:
+  weaviate:
+    image: semitechnologies/weaviate:1.28.4
+    ports:
+      - "8080:8080"
+      - "50051:50051"
+    environment:
+      AUTHENTICATION_ANONYMOUS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      CLUSTER_HOSTNAME: 'node1'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      ENABLE_MODULES: 'text2vec-openai'
+      OPENAI_APIKEY: ${OPENAI_API_KEY:-}
+      QUERY_DEFAULTS_LIMIT: '25'
+    volumes:
+      - vectorwave-dev-data:/var/lib/weaviate
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/v1/.well-known/ready || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  console:
+    image: semitechnologies/weaviate-console:latest
+    ports:
+      - "8081:8080"
+    environment:
+      WEAVIATE_URL: "http://weaviate:8080"
+    depends_on:
+      - weaviate
+
+volumes:
+  vectorwave-dev-data:

--- a/src/vectorwave/core/decorator.py
+++ b/src/vectorwave/core/decorator.py
@@ -31,6 +31,7 @@ def vectorize(search_description: Optional[str] = None,
               capture_inputs: bool = False,
               semantic_cache_filters: Optional[Dict[str, Any]] = None,
               semantic_cache_scope: Optional[List[str]] = None,
+              enable_alert: bool = True,
               **execution_tags):
     """
     VectorWave Decorator with Auto-Generation support.
@@ -199,7 +200,8 @@ def vectorize(search_description: Optional[str] = None,
             @trace_span(
                 attributes_to_capture=final_attributes,
                 capture_return_value=capture_return_value,
-                force_sync=semantic_cache
+                force_sync=semantic_cache,
+                enable_alert=enable_alert
             )
             @wraps(func)
             async def inner_wrapper(*args, **kwargs):
@@ -222,7 +224,8 @@ def vectorize(search_description: Optional[str] = None,
             @trace_span(
                 attributes_to_capture=final_attributes,
                 capture_return_value=capture_return_value,
-                force_sync=semantic_cache
+                force_sync=semantic_cache,
+                enable_alert=enable_alert
             )
             @wraps(func)
             def inner_wrapper(*args, **kwargs):

--- a/src/vectorwave/utils/replayer_semantic.py
+++ b/src/vectorwave/utils/replayer_semantic.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..core.llm.factory import get_llm_client
 from .replayer import VectorWaveReplayer
@@ -25,7 +25,8 @@ class SemanticReplayer(VectorWaveReplayer):
                limit: int = 10,
                update_baseline: bool = False,
                similarity_threshold: Optional[float] = None,
-               semantic_eval: bool = False
+               semantic_eval: bool = False,
+               mocks: Optional[Dict[str, Any]] = None
                ) -> Dict[str, Any]:
         """
         Retrieves past execution history (Golden > Standard), re-executes it,
@@ -47,7 +48,7 @@ class SemanticReplayer(VectorWaveReplayer):
             )
             return is_match, reason, ({"reason": reason} if not is_match else {})
 
-        return self._run_replay_loop(target_func, test_objects, results, update_baseline, compare_fn)
+        return self._run_replay_loop(target_func, test_objects, results, update_baseline, compare_fn, mocks=mocks)
 
     def _compare_results_semantic(self, expected: Any, actual: Any,
                                   similarity_threshold: Optional[float],

--- a/test_ex/replay_demo.py
+++ b/test_ex/replay_demo.py
@@ -1,0 +1,251 @@
+"""
+replay_demo.py - Replay 기능 실제 동작 테스트 (외부 호출 없음)
+
+실행 방법:
+  python3 test_ex/replay_demo.py
+  pytest test_ex/replay_demo.py -v
+"""
+
+import importlib
+import json
+import inspect
+import sys
+from unittest.mock import MagicMock, patch
+
+# test_ex/replay_fixtures 가 항상 동일한 경로로 임포트되도록 보장
+import test_ex.replay_fixtures as _fx
+
+
+# ── Weaviate Mock 구성 ────────────────────────────────────────────────────────
+
+def _make_mock_weaviate(exec_logs=None):
+    mock_settings = MagicMock()
+    mock_settings.EXECUTION_COLLECTION_NAME = "VectorWaveExecutions"
+    mock_settings.GOLDEN_COLLECTION_NAME = "VectorWaveGoldenDataset"
+
+    mock_exec_col = MagicMock()
+    mock_golden_col = MagicMock()
+
+    mock_exec_col.query.fetch_objects.return_value = MagicMock(objects=exec_logs or [])
+    mock_exec_col.query.fetch_object_by_id.return_value = None
+    mock_exec_col.data = MagicMock()
+
+    mock_golden_col.query.fetch_objects.return_value = MagicMock(objects=[])
+    mock_golden_col.data = MagicMock()
+
+    mock_client = MagicMock()
+
+    def _get_col(name):
+        if name == "VectorWaveGoldenDataset":
+            return mock_golden_col
+        return mock_exec_col
+
+    mock_client.collections.get.side_effect = _get_col
+    return mock_client, mock_settings, mock_exec_col
+
+
+def _make_log(uuid_str: str, inputs: dict, return_value) -> MagicMock:
+    obj = MagicMock()
+    obj.uuid = uuid_str
+    props = inputs.copy()
+    props["return_value"] = (
+        json.dumps(return_value) if not isinstance(return_value, str) else return_value
+    )
+    props["timestamp_utc"] = "2024-01-01T00:00:00Z"
+    obj.properties = props
+    return obj
+
+
+def _run_replay(func_full_name: str, func_obj, logs: list,
+                mocks=None, update_baseline: bool = False) -> dict:
+    mock_client, mock_settings, mock_exec_col = _make_mock_weaviate(exec_logs=logs)
+
+    func_name = func_full_name.rsplit(".", 1)[1]
+    mock_module = MagicMock()
+    setattr(mock_module, func_name, func_obj)
+
+    mock_importlib = MagicMock(spec=importlib)
+    mock_importlib.import_module.return_value = mock_module
+
+    with patch("vectorwave.utils.replayer.get_cached_client", return_value=mock_client), \
+         patch("vectorwave.utils.replayer.get_weaviate_settings", return_value=mock_settings), \
+         patch("vectorwave.utils.replayer.importlib", mock_importlib):
+
+        from vectorwave.utils.replayer import VectorWaveReplayer  # noqa: PLC0415
+        replayer = VectorWaveReplayer()
+
+        return replayer.replay(
+            func_full_name, limit=len(logs),
+            mocks=mocks, update_baseline=update_baseline
+        ), mock_exec_col
+
+
+# ── 테스트 케이스 ─────────────────────────────────────────────────────────────
+
+def test_순수로직_매치():
+    """외부 호출 없는 순수 함수: 예상값과 일치 → PASSED"""
+    logs = [_make_log("uuid-1", {"a": 3, "b": 4}, 7)]
+    result, _ = _run_replay("test_ex.replay_fixtures.add", _fx.add, logs)
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_순수로직_매치")
+
+
+def test_순수로직_불일치():
+    """함수 결과가 기록된 기대값과 다를 때 → FAILED (회귀 감지)"""
+    def buggy_add(a: int, b: int) -> int:
+        return a + b + 100  # 버그
+
+    buggy_add.__signature__ = inspect.signature(_fx.add)
+
+    logs = [_make_log("uuid-2", {"a": 3, "b": 4}, 7)]
+    result, _ = _run_replay("test_ex.replay_fixtures.add", buggy_add, logs)
+
+    assert result["passed"] == 0
+    assert result["failed"] == 1
+    assert result["failures"][0]["expected"] == 7
+    assert result["failures"][0]["actual"] == 107
+    print("[OK] test_순수로직_불일치")
+
+
+def test_외부호출_mocks로_차단():
+    """
+    process_order 는 _external_payment_api 를 호출한다.
+    mocks 파라미터로 해당 호출을 차단하고 가짜 응답을 주입한다.
+    """
+    expected_payment = {"status": "approved", "amount": 50.0}
+    logs = [
+        _make_log(
+            "uuid-3",
+            {"item": "book", "quantity": 2, "price_per_unit": 25.0},
+            {"item": "book", "quantity": 2, "payment": expected_payment},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks={
+            "test_ex.replay_fixtures._external_payment_api": {
+                "return_value": expected_payment
+            }
+        },
+    )
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_외부호출_mocks로_차단")
+
+
+def test_외부호출_차단없이_실행시_예외처리():
+    """mocks 없이 외부 호출 함수 실행 → RuntimeError → failed 로 기록됨"""
+    logs = [
+        _make_log(
+            "uuid-4",
+            {"item": "pen", "quantity": 1, "price_per_unit": 5.0},
+            {"item": "pen", "payment": {"status": "approved"}},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks=None,
+    )
+
+    assert result["failed"] == 1
+    assert "EXCEPTION_RAISED" in str(result["failures"][0]["actual"])
+    print("[OK] test_외부호출_차단없이_실행시_예외처리")
+
+
+def test_mocks_side_effect():
+    """side_effect 로 입력값 기반 동적 응답 주입"""
+    def dynamic_payment(amount):
+        return {"status": "approved", "amount": amount * 0.9}
+
+    logs = [
+        _make_log(
+            "uuid-5",
+            {"item": "hat", "quantity": 2, "price_per_unit": 30.0},
+            {"item": "hat", "quantity": 2,
+             "payment": {"status": "approved", "amount": 54.0}},
+        )
+    ]
+
+    result, _ = _run_replay(
+        "test_ex.replay_fixtures.process_order",
+        _fx.process_order,
+        logs,
+        mocks={
+            "test_ex.replay_fixtures._external_payment_api": {
+                "side_effect": dynamic_payment
+            }
+        },
+    )
+
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    print("[OK] test_mocks_side_effect")
+
+
+def test_update_baseline():
+    """update_baseline=True: 결과가 달라도 DB를 업데이트하고 PASSED 처리"""
+    logs = [_make_log("uuid-6", {"name": "Alice"}, "Hello, Bob!")]  # 기대값이 틀림
+
+    mock_client, mock_settings, mock_exec_col = _make_mock_weaviate(exec_logs=logs)
+
+    mock_module = MagicMock()
+    mock_module.greet = _fx.greet
+    mock_importlib = MagicMock(spec=importlib)
+    mock_importlib.import_module.return_value = mock_module
+
+    with patch("vectorwave.utils.replayer.get_cached_client", return_value=mock_client), \
+         patch("vectorwave.utils.replayer.get_weaviate_settings", return_value=mock_settings), \
+         patch("vectorwave.utils.replayer.importlib", mock_importlib):
+
+        from vectorwave.utils.replayer import VectorWaveReplayer  # noqa: PLC0415
+        replayer = VectorWaveReplayer()
+
+        result = replayer.replay(
+            "test_ex.replay_fixtures.greet",
+            limit=1,
+            update_baseline=True,
+        )
+
+    assert result["updated"] == 1
+    assert result["passed"] == 1
+    assert result["failed"] == 0
+    mock_exec_col.data.update.assert_called_once()
+    print("[OK] test_update_baseline")
+
+
+# ── 직접 실행 ─────────────────────────────────────────────────────────────────
+
+TESTS = [
+    test_순수로직_매치,
+    test_순수로직_불일치,
+    test_외부호출_mocks로_차단,
+    test_외부호출_차단없이_실행시_예외처리,
+    test_mocks_side_effect,
+    test_update_baseline,
+]
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("VectorWave Replayer 동작 테스트 (외부 호출 없음)")
+    print("=" * 60)
+
+    passed_cnt, failed_cnt = 0, 0
+    for test_fn in TESTS:
+        try:
+            test_fn()
+            passed_cnt += 1
+        except Exception as e:
+            print(f"[FAIL] {test_fn.__name__}: {e}")
+            failed_cnt += 1
+
+    print(f"\n결과: {passed_cnt} passed / {failed_cnt} failed")
+    sys.exit(1 if failed_cnt else 0)

--- a/test_ex/replay_fixtures.py
+++ b/test_ex/replay_fixtures.py
@@ -1,0 +1,26 @@
+"""
+replay_demo에서 사용하는 테스트 대상 함수들.
+별도 모듈로 분리해야 patch 경로('test_ex.replay_fixtures.*')가 항상 일정하다.
+"""
+
+
+def _external_payment_api(amount: float) -> dict:
+    """실제 환경에서는 외부 결제 API를 호출 - 테스트에서 차단해야 함"""
+    raise RuntimeError("실제 결제 API 호출됨! 테스트에서는 차단되어야 합니다.")
+
+
+def process_order(item: str, quantity: int, price_per_unit: float) -> dict:
+    """주문 처리 함수. 외부 결제 API를 호출한다."""
+    subtotal = quantity * price_per_unit
+    payment_result = _external_payment_api(subtotal)
+    return {"item": item, "quantity": quantity, "payment": payment_result}
+
+
+def add(a: int, b: int) -> int:
+    """순수 로직 함수 (외부 호출 없음)"""
+    return a + b
+
+
+def greet(name: str) -> str:
+    """순수 문자열 처리 함수"""
+    return f"Hello, {name}!"


### PR DESCRIPTION
## Summary

Introduce a real-Weaviate test environment for VectorWave so the suite no longer relies on mocked Weaviate clients. Adds a session-scoped `testcontainers` fixture, a `vectorwave dev` CLI for running scripts end-to-end, and converts the four `database/` test files to exercise a live Weaviate.

## Changes

### Test infrastructure
- `src/tests/conftest.py`
  - `weaviate_container` (session-scoped) — boots Weaviate 1.28.4 via `testcontainers`, sets `WEAVIATE_HOST/PORT/GRPC_PORT` env vars, clears `@lru_cache` singletons (`get_weaviate_settings`, `get_cached_client`, `get_vectorizer`, `get_batch_manager`), and tears down on session end.
  - `clean_weaviate` (function-scoped) — deletes the four VectorWave collections before and after each test for isolation.
  - Registers `@pytest.mark.e2e` and disables the testcontainers Ryuk reaper (our fixture handles teardown explicitly; Ryuk has been racy on macOS Docker Desktop).

### `vectorwave` CLI
- New `src/vectorwave/cli/` package with `vectorwave dev start|stop|reset|status|logs`.
- Bundles a `compose.yml` so `pip install vectorwave` users (not just contributors with `test_ex/`) can run the dev stack.
- Registered as a console script in `pyproject.toml`.

### Project metadata (`pyproject.toml`)
- `[project.optional-dependencies] dev`: `pytest`, `pytest-asyncio`, `flake8`, `testcontainers>=4.0.0`.
- `[project.scripts] vectorwave = \"vectorwave.cli:main\"`.
- `[tool.maturin] include` so the bundled `compose.yml` ships with the wheel.

### Database tests converted to e2e
| File | Before | After |
|---|---|---|
| `test_db.py` | 14 mock-based tests | 6 unit (failure paths, config validation) + 8 e2e (schema creation, idempotency, custom properties, vectorizer config) |
| `test_db_search.py` | 7 mock-based tests | 4 unit (`_build_weaviate_filters`) + 5 e2e (real `fetch_objects` and `near_vector`; `search_functions` runs through the local HuggingFace vectorizer so no OpenAI key is required) |
| `test_dataset.py` | 2 mock-based tests | 5 e2e covering `register_as_golden` (success / missing log / missing vector) and `recommend_candidates` (centroid math classifying STEADY/DISCOVERY) |
| `test_archiver.py` | 5 mock-based tests | 1 unit (`_convert_to_training_format`) + 5 e2e covering export, delete-only, status filtering, and the safety invariant where a file-write failure must abort deletion |

The guiding rule: tests that mocked Weaviate were verifying the author's mental model of the Weaviate API rather than VectorWave behaviour. Running them against a real instance now catches real schema, filter, and query semantics.

## Test Results

```
129 passed, 29 warnings in 30.38s
```

- 95 existing unit tests: unchanged, still pass.
- 34 new/converted tests in `database/`: 5 unit + 29 e2e.
- Full suite: `pytest` from a clean checkout boots one Weaviate container per session and tears it down on exit.

## Notes for reviewers

- HuggingFace embeddings are downloaded on first run (~22MB). Subsequent runs are cached.
- LLM-dependent tests (healer, auto metadata) are out of scope for this PR; a follow-up will introduce VCR-style cassettes so they can run without API keys.
- Five test files remain to convert in a follow-up: `test_execution_search`, `test_decorator`, `test_semantic_caching`, `test_replayer`, `test_batch`.