### PR TITLE
test(bench): add pytest-benchmark fixture for @vectorize overhead

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -151,6 +151,28 @@ A few things to double-check before opening a PR:
 - Lint is clean: `flake8 src/ --select=E9,F63,F7,F82`
 - The Rust extension still builds: `maturin develop`
 
+### Benchmarks
+
+Per-call overhead measurements live under `src/tests/benchmarks/` and are
+**skipped by default** so the regular suite stays fast. Run them
+explicitly:
+
+```bash
+# All benchmarks, with summary table
+pytest src/tests/benchmarks/ --benchmark-only
+
+# Save a baseline before a change, then compare after
+pytest src/tests/benchmarks/ --benchmark-only --benchmark-save=baseline
+# ... apply the change ...
+pytest src/tests/benchmarks/ --benchmark-only --benchmark-compare=baseline
+```
+
+Coverage is split between micro (single hot helper like
+`_capture_span_attributes`) and macro (full `@vectorize` wrapping a tiny
+function with the batch manager + alerter stubbed). Use the micro
+numbers to justify a Rust port of a specific helper before opening
+that surgery.
+
 ### Pre-commit hook for secret leaks
 
 A pre-commit hook scans staged files for OpenAI / Anthropic / AWS keys and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-asyncio",
+    "pytest-benchmark",
     "pytest-recording",
     "flake8",
     "testcontainers>=4.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 pythonpath = src
+
+# Benchmark tests live under src/tests/benchmarks/ and are skipped by default
+# so the regular suite stays fast. Run them explicitly with:
+#   pytest src/tests/benchmarks/ --benchmark-only
+addopts = --benchmark-skip

--- a/src/tests/benchmarks/conftest.py
+++ b/src/tests/benchmarks/conftest.py
@@ -1,0 +1,77 @@
+"""Fixtures shared by VectorWave benchmarks.
+
+The benchmarks measure pure Python overhead in `@vectorize`, so we stub the
+batch manager / alerter / vectorizer to take their cost out of the numbers.
+The point isn't to micro-optimise infra; it's to know how much CPU
+VectorWave adds to a wrapped function call before deciding what (if
+anything) to port to Rust.
+"""
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from vectorwave.models.db_config import WeaviateSettings
+
+
+class _StubBatchManager:
+    """No-op batch manager that just counts calls. Avoids the Rust queue and
+    the real Weaviate connection so we measure only the wrapper / tracer cost."""
+
+    def __init__(self):
+        self.add_calls = 0
+        self._initialized = True
+        self._shutdown_done = False
+        self.settings = WeaviateSettings()
+        self.client = None
+
+    def add_object(self, **kwargs):
+        self.add_calls += 1
+
+    def shutdown(self):
+        self._shutdown_done = True
+
+
+class _StubAlerter:
+    def __init__(self):
+        self.notify_calls = 0
+
+    def notify(self, _props):
+        self.notify_calls += 1
+
+
+@pytest.fixture
+def stubbed_vectorize_env(monkeypatch, tmp_path):
+    """Patches the heavy collaborators so `@vectorize` runs purely in Python.
+
+    Returns the stub batch manager so tests can assert on call counts if they
+    want to. Each test gets its own batch + alerter instance.
+    """
+    batch = _StubBatchManager()
+    alerter = _StubAlerter()
+
+    # Force a no-op Python vectorizer (None means "skip vectorisation").
+    monkeypatch.setenv("VECTORIZER", "none")
+    monkeypatch.setenv("WEAVIATE_HOST", "stub.invalid")
+    monkeypatch.setenv("ASYNC_LOGGING", "false")
+
+    # Use an isolated cache file under tmp so concurrent benchmarks don't
+    # collide on .vectorwave_functions_cache.json in the repo root.
+    monkeypatch.setenv("CUSTOM_PROPERTIES_FILE_PATH", str(tmp_path / ".vw_props"))
+
+    # Clear and re-stub all cached singletons.
+    from vectorwave.models.db_config import get_weaviate_settings
+    from vectorwave.batch.batch import get_batch_manager
+    from vectorwave.database.db import get_cached_client
+    from vectorwave.vectorizer.factory import get_vectorizer
+    from vectorwave.monitoring.alert.factory import get_alerter
+    for fn in (get_weaviate_settings, get_batch_manager, get_cached_client, get_vectorizer, get_alerter):
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+    monkeypatch.setattr("vectorwave.core.decorator.get_batch_manager", lambda *a, **k: batch)
+    monkeypatch.setattr("vectorwave.monitoring.tracer.get_batch_manager", lambda *a, **k: batch)
+    monkeypatch.setattr("vectorwave.monitoring.tracer.get_alerter", lambda *a, **k: alerter)
+
+    yield batch

--- a/src/tests/benchmarks/test_vectorize_overhead.py
+++ b/src/tests/benchmarks/test_vectorize_overhead.py
@@ -1,0 +1,153 @@
+"""Benchmarks for the VectorWave hot path.
+
+Run with:
+    pytest src/tests/benchmarks/ --benchmark-only
+
+Compare two runs (e.g., before/after a Rust port):
+    pytest src/tests/benchmarks/ --benchmark-only --benchmark-save=baseline
+    # ... apply changes ...
+    pytest src/tests/benchmarks/ --benchmark-only --benchmark-compare=baseline
+
+The macro benchmarks stub out the batch manager + alerter so we measure
+the Python overhead `@vectorize` adds to a function call, not Weaviate I/O.
+The micro benchmarks call the hot helpers directly to isolate which piece
+contributes the most time.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vectorwave.core.decorator import vectorize
+from vectorwave.monitoring.tracer import (
+    _capture_span_attributes,
+    _create_input_vector_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# Baseline: bare Python function with no decoration. Anchor for "what does
+# VectorWave cost on top of vanilla Python?"
+# ---------------------------------------------------------------------------
+
+def test_baseline_plain_function(benchmark):
+    """Undecorated control. The macro benchmarks below should be compared
+    against this number to read the @vectorize overhead."""
+    def add(a, b):
+        return a + b
+
+    benchmark(add, 3, 4)
+
+
+# ---------------------------------------------------------------------------
+# Macro: @vectorize wrapping a no-op sync function.
+# ---------------------------------------------------------------------------
+
+def test_vectorize_wraps_simple_sync_call(benchmark, stubbed_vectorize_env):
+    """Per-call cost of @vectorize on a tiny sync function with no captured
+    inputs. This is the closest thing to "the wrapper tax everyone pays"."""
+
+    @vectorize(
+        search_description="benchmark add",
+        sequence_narrative="benchmark add",
+    )
+    def add(a, b):
+        return a + b
+
+    # Warm up: first call pays the function-cache check + signature inspect cost.
+    for _ in range(3):
+        add(1, 2)
+
+    benchmark(add, 3, 4)
+
+
+def test_vectorize_with_capture_inputs(benchmark, stubbed_vectorize_env):
+    """Per-call cost when capture_inputs=True forces full attribute capture
+    + masking of every parameter on every call."""
+
+    @vectorize(
+        search_description="benchmark capture",
+        sequence_narrative="benchmark capture",
+        capture_inputs=True,
+    )
+    def process(user_id, amount, is_active=True, tags=("a", "b")):
+        return amount * 2
+
+    for _ in range(3):
+        process("u1", 100)
+
+    benchmark(process, "u-bench", 500)
+
+
+def test_vectorize_with_capture_return_value(benchmark, stubbed_vectorize_env):
+    """capture_return_value forces JSON serialisation of the return value;
+    measures the cost of the return-side path."""
+
+    @vectorize(
+        search_description="benchmark cap-ret",
+        sequence_narrative="benchmark cap-ret",
+        capture_return_value=True,
+    )
+    def lookup(key):
+        return {"key": key, "rows": [{"id": 1}, {"id": 2}, {"id": 3}]}
+
+    for _ in range(3):
+        lookup("k1")
+
+    benchmark(lookup, "k-bench")
+
+
+# ---------------------------------------------------------------------------
+# Micro: the two functions most likely to dominate the per-call cost.
+# These are isolated so a Rust port can target them surgically.
+# ---------------------------------------------------------------------------
+
+_SENSITIVE = {"password", "token", "api_key"}
+
+
+def _example_func(user_id, amount, is_active=True, tags=("a", "b"), password=None):
+    return amount
+
+
+def test_micro_capture_span_attributes_simple(benchmark):
+    """`_capture_span_attributes` with 5 params, no sensitive masking triggered."""
+    args = ("u1", 100)
+    kwargs = {"is_active": True, "tags": ("a", "b")}
+    attrs = ["user_id", "amount", "is_active", "tags"]
+
+    benchmark(_capture_span_attributes, attrs, args, kwargs, _example_func, _SENSITIVE)
+
+
+def test_micro_capture_span_attributes_with_masking(benchmark):
+    """Same shape but `password` triggers the sensitive-key path on every call."""
+    args = ("u1", 100)
+    kwargs = {"password": "topsecret", "tags": ("a", "b")}
+    attrs = ["user_id", "amount", "password", "tags"]
+
+    benchmark(_capture_span_attributes, attrs, args, kwargs, _example_func, _SENSITIVE)
+
+
+def test_micro_create_input_vector_data_simple(benchmark):
+    """Input-vector text construction for a small kwargs payload."""
+    benchmark(
+        _create_input_vector_data,
+        func_name="lookup_user",
+        args=("u1", 100),
+        kwargs={"region": "us-west", "active": True},
+        sensitive_keys=_SENSITIVE,
+    )
+
+
+def test_micro_create_input_vector_data_nested(benchmark):
+    """Same with a moderately nested dict to stretch the masking walker."""
+    payload = {
+        "filters": {"status": "ok", "tier": "gold", "tags": ["billing", "auth"]},
+        "page": {"limit": 50, "cursor": "abc123"},
+        "user": {"id": "u1", "password": "should-be-masked"},
+    }
+    benchmark(
+        _create_input_vector_data,
+        func_name="search",
+        args=(),
+        kwargs={"query": "find me", "payload": payload},
+        sensitive_keys=_SENSITIVE,
+    )


### PR DESCRIPTION
## Summary

Adds a small benchmark suite under `src/tests/benchmarks/` so we can ground future performance work (e.g., a Rust port of the tracer hot path) in measurements instead of guessing. Skipped by default so the regular suite stays fast; run explicitly with `pytest src/tests/benchmarks/ --benchmark-only`.

## Changes

### Coverage (8 benchmarks)

- **Baseline**: plain Python function, no decoration. Anchor for the multipliers below.
- **Macro** — full `@vectorize` wrapping a tiny sync function with the batch manager + alerter stubbed:
  - default config
  - `capture_inputs=True`
  - `capture_return_value=True`
- **Micro** — the two helpers most likely to dominate per-call cost, called directly:
  - `_capture_span_attributes` (with and without sensitive-key masking)
  - `_create_input_vector_data` (simple kwargs and a moderately nested dict)

### Wiring

- `pyproject.toml`: add `pytest-benchmark` to the `[dev]` extras.
- `pytest.ini`: `addopts = --benchmark-skip` so the regular suite is unchanged.
- `src/tests/benchmarks/conftest.py`: `stubbed_vectorize_env` swaps in no-op batch + alerter so the macro numbers measure Python overhead only — not Weaviate I/O, not the Rust queue, not vectorisation.
- `Contributing.md`: documents how to run, save a baseline, and compare.

## Bug Fix

None — pure tooling.

## Test Results

```
8 passed in 5.75s — pytest src/tests/benchmarks/ --benchmark-only
8 skipped in 0.01s — default `pytest` run (benchmarks are auto-skipped)
```

Initial numbers on a Mac dev machine:

| Benchmark | Mean | × baseline |
|---|---|---|
| Plain Python `add` (baseline) | 36 ns | 1× |
| `_create_input_vector_data` simple | 1.5 µs | 42× |
| `_create_input_vector_data` nested | 3.3 µs | 93× |
| `_capture_span_attributes` simple | 4.3 µs | 118× |
| `_capture_span_attributes` masked | 4.0 µs | 111× |
| `@vectorize` simple call | **11 µs** | 311× |
| `@vectorize` + capture_return_value | 12.8 µs | 355× |
| `@vectorize` + capture_inputs | 13.4 µs | 370× |

The two micro helpers account for ~5–7 µs of the 11 µs end-to-end overhead, so they're the right targets if a future profile shows VectorWave on a hot list. For the intended use case (wrapping LLM calls / DB queries / business logic) the absolute number is invisible.

## Notes for reviewers

- `--benchmark-save=baseline` followed by `--benchmark-compare=baseline` after a change gives a side-by-side diff — the intended workflow before opening any optimisation PR.
- Benchmarks deliberately stub the batch manager. If you want to bench real I/O too, point them at the testcontainer fixture and remove the stub fixture; that's a separate suite.