### PR TITLE
feat(store): Lite mode (LanceDB) via VectorStore abstraction

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -22,6 +22,26 @@ vectorwave dev start
 You should now be able to run any script under `test_ex/` and see VectorWave
 write to the local Weaviate.
 
+## Modes: Pro vs Lite
+
+VectorWave's storage layer is now backend-agnostic via the `VectorStore`
+interface (`src/vectorwave/store/`). Two backends ship today:
+
+| Mode | Backend | Set with | Use when |
+|---|---|---|---|
+| `pro` (default) | Weaviate via Docker compose | unset or `VECTORWAVE_MODE=pro` | production, full feature set |
+| `lite` | LanceDB local file store | `VECTORWAVE_MODE=lite` | hackathons, Colab, quick demos — no Docker |
+
+In Lite mode VectorWave writes to `.vectorwave/lance/` (override with
+`VECTORWAVE_LITE_PATH`) and works offline with `pip install vectorwave`
+plus a Python-side vectorizer (default: HuggingFace `all-MiniLM-L6-v2`).
+
+Lite mode currently supports the core `@vectorize` flow: function
+metadata, execution logs, basic filter/sort fetch via
+`find_executions`, and vector cache lookup. Hybrid search and Weaviate's
+modular vectorizers (`text2vec-openai` etc.) remain Pro-only — see
+issue #95 for the migration roadmap.
+
 ## Dev environment CLI
 
 `vectorwave dev` manages a containerised Weaviate + console stack so you

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,12 @@ dev = [
     "pytest-benchmark",
     "pytest-recording",
     "flake8",
+    "lancedb>=0.30.0",
     "testcontainers>=4.0.0",
     "vcrpy>=6.0.0",
+]
+lite = [
+    "lancedb>=0.30.0",
 ]
 
 [project.scripts]

--- a/src/tests/test_lite_mode.py
+++ b/src/tests/test_lite_mode.py
@@ -1,0 +1,145 @@
+"""End-to-end coverage for VectorWave Lite mode (LanceDB backend).
+
+These tests bypass the testcontainer Weaviate fixture entirely — Lite mode's
+whole point is "no Docker required". Each test gets a fresh LanceDB
+directory under tmp_path and verifies the @vectorize → batch → store flow
+without ever touching Weaviate.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vectorwave.core.decorator import vectorize
+from vectorwave.search.execution_search import find_executions
+
+
+def _wait_until_count(query_fn, expected: int, timeout: float = 8.0) -> int:
+    deadline = time.time() + timeout
+    last = -1
+    while time.time() < deadline:
+        last = len(query_fn())
+        if last >= expected:
+            return last
+        time.sleep(0.1)
+    raise AssertionError(f"expected at least {expected} rows, got {last}")
+
+
+def _clear_caches():
+    from vectorwave.batch.batch import get_batch_manager
+    from vectorwave.models.db_config import get_weaviate_settings
+    from vectorwave.store.factory import get_vector_store
+    from vectorwave.vectorizer.factory import get_vectorizer
+    for fn in (get_batch_manager, get_weaviate_settings, get_vector_store, get_vectorizer):
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+
+
+@pytest.fixture
+def lite_mode_env(monkeypatch, tmp_path):
+    """Configure VectorWave for Lite mode against an isolated LanceDB dir."""
+    monkeypatch.setenv("VECTORWAVE_MODE", "lite")
+    monkeypatch.setenv("VECTORWAVE_LITE_PATH", str(tmp_path / "lance"))
+    monkeypatch.setenv("VECTORIZER", "none")
+    monkeypatch.setenv("BATCH_THRESHOLD", "1")
+    monkeypatch.setenv("FLUSH_INTERVAL_SECONDS", "0.1")
+    # Make sure WeaviateSettings doesn't try a real cloud key from .env
+    monkeypatch.delenv("WEAVIATE_API_KEY", raising=False)
+    monkeypatch.setenv("WEAVIATE_HOST", "lite-mode.invalid")
+    _clear_caches()
+
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+    # Sanity: make sure we got the Lite backend, not a stale Pro singleton.
+    assert store.backend_name == "lance", f"expected lance, got {store.backend_name}"
+
+    # Pre-create the collection so the first @vectorize decoration succeeds
+    # even though no auto-schema exists in Lite mode.
+    from vectorwave.models.db_config import get_weaviate_settings
+    settings = get_weaviate_settings()
+    for coll in (settings.COLLECTION_NAME, settings.EXECUTION_COLLECTION_NAME):
+        if not store.collection_exists(coll):
+            store.ensure_collection(coll, properties=[])
+
+    yield settings
+    _clear_caches()
+
+
+def test_lite_mode_logs_call_to_lance(lite_mode_env):
+    """A decorated call lands in LanceDB without any Weaviate involvement."""
+    settings = lite_mode_env
+
+    @vectorize(search_description="Lite test", sequence_narrative="Lite test")
+    def my_lite_fn(x):
+        return x * 2
+
+    assert my_lite_fn(21) == 42
+
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+
+    # Wait for the SUCCESS row to materialise; query the executions collection.
+    _wait_until_count(
+        lambda: store.query(settings.EXECUTION_COLLECTION_NAME, limit=10),
+        expected=1,
+    )
+
+    records = store.query(settings.EXECUTION_COLLECTION_NAME, limit=10)
+    assert len(records) >= 1
+    success_records = [r for r in records if r.properties.get("status") == "SUCCESS"]
+    assert len(success_records) == 1
+    assert success_records[0].properties["function_name"] == "my_lite_fn"
+
+
+def test_lite_mode_search_executions_filter(lite_mode_env):
+    """`find_executions` works against the Lite backend."""
+    settings = lite_mode_env
+
+    @vectorize(search_description="Lite filter", sequence_narrative="Lite filter")
+    def filtered_fn(query):
+        if query == "fail":
+            raise ValueError("oops")
+        return "ok"
+
+    assert filtered_fn("ok") == "ok"
+    with pytest.raises(ValueError):
+        filtered_fn("fail")
+
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+    _wait_until_count(
+        lambda: store.query(settings.EXECUTION_COLLECTION_NAME, limit=10),
+        expected=2,
+    )
+
+    successes = find_executions(filters={"status": "SUCCESS"}, limit=10)
+    failures = find_executions(filters={"status": "ERROR"}, limit=10)
+    assert any(r["function_name"] == "filtered_fn" for r in successes)
+    assert any(r["function_name"] == "filtered_fn" for r in failures)
+    # And the filter actually narrows results
+    assert all(r["status"] == "SUCCESS" for r in successes)
+    assert all(r["status"] == "ERROR" for r in failures)
+
+
+def test_lite_mode_does_not_touch_weaviate(lite_mode_env, monkeypatch):
+    """Sanity: a Lite-mode call must never call into the Weaviate connection helpers."""
+    from vectorwave.database import db as db_mod
+    calls = []
+    real = db_mod.get_weaviate_client
+
+    def _spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(db_mod, "get_weaviate_client", _spy)
+
+    @vectorize(search_description="No-weaviate", sequence_narrative="No-weaviate")
+    def no_weaviate_fn(n):
+        return n
+
+    no_weaviate_fn(1)
+    no_weaviate_fn(2)
+    # Allow the batch worker thread to drain.
+    time.sleep(0.5)
+    assert calls == [], f"Lite mode unexpectedly called Weaviate: {calls}"

--- a/src/vectorwave/batch/batch.py
+++ b/src/vectorwave/batch/batch.py
@@ -1,3 +1,4 @@
+import os
 import weaviate
 import atexit
 import logging
@@ -34,6 +35,11 @@ class WeaviateBatchManager:
         self.settings: WeaviateSettings = get_weaviate_settings()
         self.client: Optional[weaviate.WeaviateClient] = None
 
+        # Lite mode (LanceDB local file store) skips the Weaviate client entirely.
+        # When VECTORWAVE_MODE=lite, _flush_batch_core delegates to the
+        # configured VectorStore so no Docker / Weaviate connection is needed.
+        self._lite_mode = os.environ.get("VECTORWAVE_MODE", "pro").lower() == "lite"
+
         # Store dynamic connection params
         self._host = host
         self._port = port
@@ -66,7 +72,19 @@ class WeaviateBatchManager:
         atexit.register(self.shutdown)
 
     def _connect_client(self):
-        """Attempts to connect to Weaviate."""
+        """Attempts to connect to the configured backend (Weaviate or Lite store)."""
+        if self._lite_mode:
+            try:
+                from ..store import get_vector_store
+                store = get_vector_store()
+                if store.is_ready():
+                    self._initialized = True
+                    self.client = None  # not used in Lite mode
+            except Exception as e:
+                logger.warning(f"Lite store init failed: {e}")
+                self._initialized = False
+            return
+
         try:
             if self._host is not None:
                 self.client = get_weaviate_client(
@@ -109,17 +127,27 @@ class WeaviateBatchManager:
     def _flush_batch_core(self, items: List[Dict[str, Any]]):
         """
         The actual flush logic called by either Rust or Python worker.
+
+        In Pro mode (default) this uses Weaviate's bulk batch.dynamic() context.
+        In Lite mode it groups items by collection and calls
+        VectorStore.insert_many — LanceDB has no equivalent of Weaviate's
+        single-context bulk write, but per-collection batching is fine for the
+        Lite use case.
         """
         if not items:
             return
 
         # 1. Check/Retry Connection
-        if not self._initialized or not self.client:
+        if not self._initialized or (not self._lite_mode and not self.client):
             self._connect_client()
             if not self._initialized:
                 return
 
-        # 2. Send Batch via Weaviate Client
+        if self._lite_mode:
+            self._flush_via_store(items)
+            return
+
+        # 2. Send Batch via Weaviate Client (Pro mode)
         try:
             # Weaviate v4 batch context
             with self.client.batch.dynamic() as batch:
@@ -142,6 +170,31 @@ class WeaviateBatchManager:
             if "shutdown" in msg or "closed" in msg:
                 return
             logger.error(f"❌ Batch Flush Error: {e}")
+
+    def _flush_via_store(self, items: List[Dict[str, Any]]):
+        """Lite-mode flush: route items through the VectorStore abstraction."""
+        from ..store import get_vector_store
+        try:
+            store = get_vector_store()
+        except Exception as e:
+            logger.error(f"❌ Lite store unavailable: {e}")
+            return
+        by_collection: Dict[str, List[Dict[str, Any]]] = {}
+        for item in items:
+            by_collection.setdefault(item["collection"], []).append({
+                "properties": item["properties"],
+                "uuid": item.get("uuid"),
+                "vector": item.get("vector"),
+            })
+        for collection, batch in by_collection.items():
+            try:
+                # Lite stores create tables lazily, but ensure the schema exists
+                # so writes don't fail with "table not found".
+                if not store.collection_exists(collection):
+                    store.ensure_collection(collection, properties=[])
+                store.insert_many(collection, batch)
+            except Exception as e:
+                logger.error(f"❌ Lite batch flush failed for '{collection}': {e}")
 
     # --- Legacy Python Worker Methods (Only used if Rust is missing) ---
     def _python_worker_loop(self):

--- a/src/vectorwave/database/db_search.py
+++ b/src/vectorwave/database/db_search.py
@@ -202,38 +202,31 @@ def search_executions(
         sort_by: Optional[str] = "timestamp_utc",
         sort_ascending: bool = False
 ) -> List[Dict[str, Any]]:
-    # ... (No changes needed here)
     """
     Searches execution logs from the [VectorWaveExecutions] collection using filtering and sorting.
+
+    Routes through the VectorStore abstraction so it works in both Pro
+    (Weaviate) and Lite (LanceDB) modes.
     """
     try:
+        from ..store import get_vector_store
         settings: WeaviateSettings = get_weaviate_settings()
-        client: weaviate.WeaviateClient = get_cached_client()
-
-        collection = client.collections.get(settings.EXECUTION_COLLECTION_NAME)
-        weaviate_filter = _build_weaviate_filters(filters)
-        weaviate_sort = None
-
-        if sort_by:
-            weaviate_sort = wvc.query.Sort.by_property(
-                name=sort_by,
-                ascending=sort_ascending
-            )
-
-        response = collection.query.fetch_objects(
+        store = get_vector_store()
+        records = store.query(
+            collection=settings.EXECUTION_COLLECTION_NAME,
+            filters=filters,
+            sort_by=sort_by,
+            sort_ascending=sort_ascending,
             limit=limit,
-            filters=weaviate_filter,
-            sort=weaviate_sort
         )
         results = []
-        for obj in response.objects:
-            props = obj.properties.copy()
-            props['uuid'] = str(obj.uuid)
-            for key, value in props.items():
+        for rec in records:
+            props = dict(rec.properties)
+            props["uuid"] = rec.uuid
+            for key, value in list(props.items()):
                 if isinstance(value, uuid.UUID) or isinstance(value, datetime):
                     props[key] = str(value)
             results.append(props)
-
         return results
 
     except Exception as e:

--- a/src/vectorwave/store/__init__.py
+++ b/src/vectorwave/store/__init__.py
@@ -1,0 +1,19 @@
+"""Backend-agnostic vector store interface.
+
+VectorWave historically wired Weaviate's v4 client directly into batch /
+search / replayer / archiver code. To support a Docker-less "Lite" mode
+(see issue #95), the store layer abstracts the operations everyone
+shares — insert, query, near_vector, update, delete — so each backend
+can satisfy them independently.
+
+Backends today:
+
+- ``WeaviateVectorStore`` (Pro / default)  — wraps the existing client
+- ``LanceVectorStore``     (Lite)          — local LanceDB, no Docker
+
+Pick one via ``get_vector_store()`` (env: ``VECTORWAVE_MODE``).
+"""
+from .base import StoreRecord, VectorStore
+from .factory import get_vector_store
+
+__all__ = ["StoreRecord", "VectorStore", "get_vector_store"]

--- a/src/vectorwave/store/base.py
+++ b/src/vectorwave/store/base.py
@@ -1,0 +1,144 @@
+"""Abstract vector-store interface.
+
+Designed against the operations VectorWave actually performs today
+(`batch.add_object`, `db_search.search_executions`, near_vector cache
+lookup, replay fetches, archiver delete). Each backend implements the
+methods below; callers should never reach past the interface to a
+backend-specific client.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class StoreRecord:
+    """Backend-agnostic shape for a single object returned from the store.
+
+    ``properties`` is the user-facing dict (function_name, status, etc.).
+    ``vector`` is the stored embedding when ``include_vector=True`` was
+    requested, otherwise None. ``distance`` is the cosine/L2 distance from
+    the query vector when the record came out of a vector search.
+    """
+    uuid: str
+    properties: Dict[str, Any]
+    vector: Optional[List[float]] = None
+    distance: Optional[float] = None
+    certainty: Optional[float] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+class VectorStore(ABC):
+    """Common contract for VectorWave's storage backends."""
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def is_ready(self) -> bool: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def collection_exists(self, collection: str) -> bool: ...
+
+    @abstractmethod
+    def ensure_collection(
+        self,
+        collection: str,
+        properties: List[Dict[str, Any]],
+        vector_dim: Optional[int] = None,
+    ) -> None:
+        """Create the collection if missing. ``properties`` is a list of
+        ``{"name": str, "data_type": str, "tokenization": Optional[str]}``
+        dicts. ``vector_dim`` is required by some backends (LanceDB) and
+        ignored by others (Weaviate self-provided)."""
+
+    @abstractmethod
+    def delete_collection(self, collection: str) -> None: ...
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def insert(
+        self,
+        collection: str,
+        properties: Dict[str, Any],
+        uuid: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+    ) -> str:
+        """Insert one object. Returns the assigned UUID."""
+
+    @abstractmethod
+    def insert_many(self, collection: str, items: List[Dict[str, Any]]) -> int:
+        """Insert N objects. Each item:
+        ``{"properties": ..., "uuid": ..., "vector": ...}``
+        Returns the count successfully written."""
+
+    @abstractmethod
+    def update(self, collection: str, uuid: str, properties: Dict[str, Any]) -> None: ...
+
+    @abstractmethod
+    def delete_by_filter(self, collection: str, filters: Dict[str, Any]) -> int:
+        """Delete every record matching ``filters``. Returns the deleted count."""
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def fetch_by_id(
+        self,
+        collection: str,
+        uuid: str,
+        include_vector: bool = False,
+    ) -> Optional[StoreRecord]: ...
+
+    @abstractmethod
+    def query(
+        self,
+        collection: str,
+        filters: Optional[Dict[str, Any]] = None,
+        sort_by: Optional[str] = None,
+        sort_ascending: bool = False,
+        limit: int = 10,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        """Filter + sort fetch. Used by archiver / replayer / search_executions."""
+
+    @abstractmethod
+    def near_vector(
+        self,
+        collection: str,
+        vector: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        certainty: Optional[float] = None,
+        limit: int = 1,
+        include_vector: bool = False,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        """Vector similarity search. ``certainty`` is interpreted as
+        ``(1 + cos_sim) / 2`` — backends that don't provide it natively
+        compute it from the distance."""
+
+    @abstractmethod
+    def iterate(self, collection: str, batch_size: int = 100) -> Iterable[StoreRecord]:
+        """Stream every record in a collection (used by token-usage aggregation)."""
+
+    # ------------------------------------------------------------------
+    # Identification (helps tests / docs / logs)
+    # ------------------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def backend_name(self) -> str: ...

--- a/src/vectorwave/store/factory.py
+++ b/src/vectorwave/store/factory.py
@@ -1,0 +1,43 @@
+"""Factory for the configured VectorWave backend.
+
+The mode is selected by the ``VECTORWAVE_MODE`` env var:
+
+- ``pro`` (default) — Weaviate via the existing client
+- ``lite`` — LanceDB local file store, no Docker
+
+The cached singleton matches the rest of the package's ``@lru_cache``
+pattern. Tests that need a fresh backend should call
+``get_vector_store.cache_clear()`` after toggling env vars.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+
+from .base import VectorStore
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache()
+def get_vector_store() -> VectorStore:
+    mode = os.environ.get("VECTORWAVE_MODE", "pro").lower()
+
+    if mode == "lite":
+        from .lance_store import LanceVectorStore
+
+        db_path = os.environ.get("VECTORWAVE_LITE_PATH", ".vectorwave/lance")
+        logger.info("[VectorWave] Lite mode active — LanceDB at %s", db_path)
+        return LanceVectorStore(db_path=db_path)
+
+    if mode in ("pro", "weaviate"):
+        from ..database.db import get_cached_client
+        from .weaviate_store import WeaviateVectorStore
+
+        logger.info("[VectorWave] Pro mode active — Weaviate")
+        return WeaviateVectorStore(client=get_cached_client())
+
+    raise ValueError(
+        f"Unknown VECTORWAVE_MODE='{mode}'. Expected 'pro' (default) or 'lite'."
+    )

--- a/src/vectorwave/store/lance_store.py
+++ b/src/vectorwave/store/lance_store.py
@@ -1,0 +1,363 @@
+"""LanceDB-backed VectorStore implementation (VectorWave Lite mode).
+
+Provides a Docker-less, file-based vector store for hackathon / Colab /
+local-dev use. Tradeoffs vs the Weaviate backend:
+
+- ✅ Zero infrastructure: a directory under ``.vectorwave/lance/`` holds everything
+- ✅ Vector + filter + sort search are supported
+- ⚠️  Hybrid search (BM25 + vector) and Weaviate's modular vectorizers are
+   not available; Lite mode requires a Python-side vectorizer (HF / OpenAI client)
+- ⚠️  Filtering happens in Python after fetch (good enough for ≲100k rows; if
+   you outgrow Lite, switch to Weaviate)
+
+Each VectorWave collection becomes a LanceDB table with a fixed schema
+``(uuid: string, vector: list<float32, dim>, payload: string)`` — every
+property is stuffed into the JSON ``payload`` so the same code can host
+arbitrary VectorWave property shapes without per-collection schemas. We
+trade a bit of query speed for schema simplicity. For Lite use this is the
+right call.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid4
+
+from .base import StoreRecord, VectorStore
+
+logger = logging.getLogger(__name__)
+
+# Default embedding dim (HF all-MiniLM-L6-v2). Lite mode users typically run with
+# `VECTORIZER=huggingface`; this matches that.
+DEFAULT_VECTOR_DIM = 384
+
+
+def _serialize_properties(props: Dict[str, Any]) -> str:
+    return json.dumps(props, default=str, ensure_ascii=False)
+
+
+def _deserialize_properties(blob: Optional[str]) -> Dict[str, Any]:
+    if not blob:
+        return {}
+    try:
+        return json.loads(blob)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _matches_filter(props: Dict[str, Any], filters: Optional[Dict[str, Any]]) -> bool:
+    """Mirror ``_build_weaviate_filter`` semantics in Python.
+
+    Supports the same operator suffixes (``__equal``, ``__not_equal``,
+    ``__gte``, ``__gt``, ``__lte``, ``__lt``, ``__like``) so the rest of the
+    codebase can use the same filter shape with either backend.
+    """
+    if not filters:
+        return True
+    for key, value in filters.items():
+        segments = key.split("__")
+        prop = segments[0]
+        op = segments[1] if len(segments) > 1 else "equal"
+        actual = props.get(prop)
+        if op == "equal":
+            if isinstance(value, list):
+                if actual not in value:
+                    return False
+            else:
+                if actual != value:
+                    return False
+        elif op == "not_equal":
+            if actual == value:
+                return False
+        elif op == "gte":
+            if actual is None or actual < value:
+                return False
+        elif op == "gt":
+            if actual is None or actual <= value:
+                return False
+        elif op == "lte":
+            if actual is None or actual > value:
+                return False
+        elif op == "lt":
+            if actual is None or actual >= value:
+                return False
+        elif op == "like":
+            if not isinstance(actual, str) or value not in actual:
+                return False
+        else:
+            logger.warning("Unknown filter op '%s' on '%s'; treating as equal.", op, prop)
+            if actual != value:
+                return False
+    return True
+
+
+def _row_to_record(row: Dict[str, Any], include_vector: bool = False, distance: Optional[float] = None) -> StoreRecord:
+    props = _deserialize_properties(row.get("payload"))
+    vector = None
+    if include_vector and row.get("vector") is not None:
+        vector = list(row["vector"])
+    cert = (1.0 - distance / 2) if distance is not None else None
+    return StoreRecord(
+        uuid=row["uuid"],
+        properties=props,
+        vector=vector,
+        distance=distance,
+        certainty=cert,
+    )
+
+
+class LanceVectorStore(VectorStore):
+    backend_name = "lance"
+
+    def __init__(self, db_path: str = ".vectorwave/lance", vector_dim: int = DEFAULT_VECTOR_DIM):
+        try:
+            import lancedb
+        except ImportError as e:
+            raise ImportError(
+                "LanceDB is required for VectorWave Lite mode. "
+                "Install with `pip install lancedb`."
+            ) from e
+        os.makedirs(db_path, exist_ok=True)
+        self._lancedb = lancedb
+        self._db = lancedb.connect(db_path)
+        self._db_path = db_path
+        self._vector_dim = vector_dim
+        self._open_tables: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def is_ready(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self._open_tables.clear()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def collection_exists(self, collection: str) -> bool:
+        return collection in self._db.list_tables()
+
+    def ensure_collection(
+        self,
+        collection: str,
+        properties: List[Dict[str, Any]],
+        vector_dim: Optional[int] = None,
+    ) -> None:
+        if collection in self._db.list_tables():
+            return
+        import pyarrow as pa
+        dim = vector_dim or self._vector_dim
+        schema = pa.schema(
+            [
+                pa.field("uuid", pa.string()),
+                pa.field("vector", pa.list_(pa.float32(), dim)),
+                pa.field("payload", pa.string()),
+            ]
+        )
+        # `exist_ok=True` makes ensure_collection truly idempotent across the
+        # in-memory list_tables cache and any concurrent worker — if the table
+        # is already on disk we just no-op and move on.
+        try:
+            self._db.create_table(collection, schema=schema, exist_ok=True)
+        except TypeError:
+            # Older lancedb versions don't accept exist_ok; fall back to
+            # catching the existence error.
+            try:
+                self._db.create_table(collection, schema=schema, mode="create")
+            except ValueError as e:
+                if "already exists" not in str(e):
+                    raise
+
+    def delete_collection(self, collection: str) -> None:
+        if collection in self._db.list_tables():
+            self._db.drop_table(collection)
+            self._open_tables.pop(collection, None)
+
+    def _open(self, collection: str):
+        cached = self._open_tables.get(collection)
+        if cached is not None:
+            return cached
+        if collection not in self._db.list_tables():
+            # Collections appear lazily — create with the default schema if a
+            # caller writes before calling ensure_collection.
+            self.ensure_collection(collection, properties=[])
+        tbl = self._db.open_table(collection)
+        self._open_tables[collection] = tbl
+        return tbl
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def insert(
+        self,
+        collection: str,
+        properties: Dict[str, Any],
+        uuid: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+    ) -> str:
+        uuid = uuid or str(uuid4())
+        vec = list(vector) if vector is not None else [0.0] * self._vector_dim
+        if len(vec) != self._vector_dim:
+            # Pad / truncate so the schema's fixed-size list is satisfied. Logged
+            # so callers notice, but we keep going so a Lite user with a stray
+            # different-dim vector doesn't get a hard crash.
+            logger.warning(
+                "Vector dim %d != table dim %d for collection '%s'; padding/truncating.",
+                len(vec), self._vector_dim, collection,
+            )
+            if len(vec) < self._vector_dim:
+                vec = vec + [0.0] * (self._vector_dim - len(vec))
+            else:
+                vec = vec[: self._vector_dim]
+        tbl = self._open(collection)
+        tbl.add([{"uuid": uuid, "vector": vec, "payload": _serialize_properties(properties)}])
+        return uuid
+
+    def insert_many(self, collection: str, items: List[Dict[str, Any]]) -> int:
+        if not items:
+            return 0
+        tbl = self._open(collection)
+        rows = []
+        for it in items:
+            uuid = it.get("uuid") or str(uuid4())
+            vec = it.get("vector")
+            vec = list(vec) if vec is not None else [0.0] * self._vector_dim
+            if len(vec) != self._vector_dim:
+                if len(vec) < self._vector_dim:
+                    vec = vec + [0.0] * (self._vector_dim - len(vec))
+                else:
+                    vec = vec[: self._vector_dim]
+            rows.append({
+                "uuid": uuid,
+                "vector": vec,
+                "payload": _serialize_properties(it["properties"]),
+            })
+        tbl.add(rows)
+        return len(rows)
+
+    def update(self, collection: str, uuid: str, properties: Dict[str, Any]) -> None:
+        tbl = self._open(collection)
+        # Read current row, merge properties, rewrite. LanceDB's `update` API
+        # works on column expressions; for our JSON-blob schema that's awkward,
+        # so we delete + re-insert with the same UUID. The vector is preserved.
+        rows = tbl.search().where(f"uuid = '{uuid}'").limit(1).to_list()
+        if not rows:
+            logger.warning("update: uuid '%s' not found in '%s'", uuid, collection)
+            return
+        existing = rows[0]
+        merged = _deserialize_properties(existing.get("payload"))
+        merged.update(properties)
+        tbl.delete(f"uuid = '{uuid}'")
+        tbl.add(
+            [{
+                "uuid": uuid,
+                "vector": list(existing.get("vector") or [0.0] * self._vector_dim),
+                "payload": _serialize_properties(merged),
+            }]
+        )
+
+    def delete_by_filter(self, collection: str, filters: Dict[str, Any]) -> int:
+        if not filters:
+            return 0
+        tbl = self._open(collection)
+        # LanceDB's `delete` takes a SQL expression. We can't easily push our
+        # dict-style filters down without translating each operator, so do a
+        # Python-side fetch + bulk delete by uuid list.
+        all_rows = tbl.to_pandas().to_dict("records")
+        targets = [r["uuid"] for r in all_rows
+                   if _matches_filter(_deserialize_properties(r.get("payload")), filters)]
+        if not targets:
+            return 0
+        # SQL-escape uuids (they are generated UUIDs / safe strings) and delete.
+        uuid_list = ",".join(f"'{u}'" for u in targets)
+        tbl.delete(f"uuid IN ({uuid_list})")
+        return len(targets)
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def fetch_by_id(
+        self,
+        collection: str,
+        uuid: str,
+        include_vector: bool = False,
+    ) -> Optional[StoreRecord]:
+        tbl = self._open(collection)
+        rows = tbl.search().where(f"uuid = '{uuid}'").limit(1).to_list()
+        if not rows:
+            return None
+        return _row_to_record(rows[0], include_vector=include_vector)
+
+    def query(
+        self,
+        collection: str,
+        filters: Optional[Dict[str, Any]] = None,
+        sort_by: Optional[str] = None,
+        sort_ascending: bool = False,
+        limit: int = 10,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        tbl = self._open(collection)
+        # Fetch-all-then-filter — fine for Lite mode dataset sizes.
+        df = tbl.to_pandas()
+        records: List[StoreRecord] = []
+        rows = df.to_dict("records")
+        filtered = [r for r in rows if _matches_filter(_deserialize_properties(r.get("payload")), filters)]
+        if sort_by:
+            def _sort_key(row):
+                key = _deserialize_properties(row.get("payload")).get(sort_by)
+                # None values sort last regardless of order
+                return (key is None, key)
+            filtered.sort(key=_sort_key, reverse=not sort_ascending)
+        filtered = filtered[: limit]
+        for r in filtered:
+            records.append(_row_to_record(r))
+        return records
+
+    def near_vector(
+        self,
+        collection: str,
+        vector: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        certainty: Optional[float] = None,
+        limit: int = 1,
+        include_vector: bool = False,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        tbl = self._open(collection)
+        vec = list(vector)
+        if len(vec) != self._vector_dim:
+            if len(vec) < self._vector_dim:
+                vec = vec + [0.0] * (self._vector_dim - len(vec))
+            else:
+                vec = vec[: self._vector_dim]
+        # Fetch a generous superset; we filter + truncate in Python.
+        fetch_limit = max(limit * 5, 50)
+        rows = tbl.search(vec).limit(fetch_limit).to_list()
+        out: List[StoreRecord] = []
+        for r in rows:
+            props = _deserialize_properties(r.get("payload"))
+            if not _matches_filter(props, filters):
+                continue
+            distance = float(r.get("_distance", 0.0))
+            cert = max(0.0, 1.0 - distance / 2.0)
+            if certainty is not None and cert < certainty:
+                continue
+            rec = _row_to_record(r, include_vector=include_vector, distance=distance)
+            out.append(rec)
+            if len(out) >= limit:
+                break
+        return out
+
+    def iterate(self, collection: str, batch_size: int = 100) -> Iterable[StoreRecord]:
+        tbl = self._open(collection)
+        for r in tbl.to_pandas().to_dict("records"):
+            yield _row_to_record(r)

--- a/src/vectorwave/store/lance_store.py
+++ b/src/vectorwave/store/lance_store.py
@@ -270,7 +270,8 @@ class LanceVectorStore(VectorStore):
         # LanceDB's `delete` takes a SQL expression. We can't easily push our
         # dict-style filters down without translating each operator, so do a
         # Python-side fetch + bulk delete by uuid list.
-        all_rows = tbl.to_pandas().to_dict("records")
+        # `to_arrow().to_pylist()` keeps us off the pandas dependency path.
+        all_rows = tbl.to_arrow().to_pylist()
         targets = [r["uuid"] for r in all_rows
                    if _matches_filter(_deserialize_properties(r.get("payload")), filters)]
         if not targets:
@@ -306,10 +307,10 @@ class LanceVectorStore(VectorStore):
         return_properties: Optional[List[str]] = None,
     ) -> List[StoreRecord]:
         tbl = self._open(collection)
-        # Fetch-all-then-filter — fine for Lite mode dataset sizes.
-        df = tbl.to_pandas()
+        # Fetch-all-then-filter — fine for Lite mode dataset sizes. Using
+        # to_arrow keeps the runtime free of a pandas dependency.
+        rows = tbl.to_arrow().to_pylist()
         records: List[StoreRecord] = []
-        rows = df.to_dict("records")
         filtered = [r for r in rows if _matches_filter(_deserialize_properties(r.get("payload")), filters)]
         if sort_by:
             def _sort_key(row):
@@ -359,5 +360,5 @@ class LanceVectorStore(VectorStore):
 
     def iterate(self, collection: str, batch_size: int = 100) -> Iterable[StoreRecord]:
         tbl = self._open(collection)
-        for r in tbl.to_pandas().to_dict("records"):
+        for r in tbl.to_arrow().to_pylist():
             yield _row_to_record(r)

--- a/src/vectorwave/store/weaviate_store.py
+++ b/src/vectorwave/store/weaviate_store.py
@@ -1,0 +1,306 @@
+"""Weaviate-backed VectorStore implementation.
+
+Wraps the existing client/get_cached_client logic so the rest of the
+codebase can talk to a backend-neutral interface while production
+deployments keep using Weaviate.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+import weaviate
+import weaviate.classes.config as wvc
+import weaviate.classes.query as wvc_query
+from weaviate.classes.config import Tokenization
+from weaviate.classes.query import Filter
+
+from .base import StoreRecord, VectorStore
+
+logger = logging.getLogger(__name__)
+
+_PROP_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _build_weaviate_filter(filters: Optional[Dict[str, Any]]):
+    """Translate the dict-style filter we use across the codebase into a
+    Weaviate ``Filter``. Mirrors the behaviour previously implemented
+    inline in ``db_search._build_weaviate_filters`` so existing callers
+    keep working unchanged."""
+    if not filters:
+        return None
+
+    parts = []
+    for key, value in filters.items():
+        segments = key.split("__")
+        prop_name = segments[0]
+        op = segments[1] if len(segments) > 1 else "equal"
+
+        if not _PROP_NAME_PATTERN.match(prop_name):
+            logger.warning("Rejecting unsafe filter prop name '%s'", prop_name)
+            continue
+
+        prop = Filter.by_property(prop_name)
+        try:
+            if op == "equal":
+                if isinstance(value, list) and value:
+                    parts.append(prop.contains_any(value))
+                else:
+                    parts.append(prop.equal(value))
+            elif op == "not_equal":
+                parts.append(prop.not_equal(value))
+            elif op == "gte":
+                parts.append(prop.greater_or_equal(value))
+            elif op == "gt":
+                parts.append(prop.greater_than(value))
+            elif op == "lte":
+                parts.append(prop.less_or_equal(value))
+            elif op == "lt":
+                parts.append(prop.less_than(value))
+            elif op == "like":
+                parts.append(prop.like(f"*{value}*"))
+            else:
+                logger.warning("Unknown filter operator '%s' on '%s' — using equal.", op, prop_name)
+                parts.append(prop.equal(value))
+        except Exception as e:
+            logger.error("Failed to build filter for '%s': %s", key, e)
+
+    if not parts:
+        return None
+    return Filter.all_of(parts)
+
+
+def _to_record(obj, include_vector: bool = False) -> StoreRecord:
+    metadata = getattr(obj, "metadata", None)
+    distance = getattr(metadata, "distance", None) if metadata is not None else None
+    certainty = getattr(metadata, "certainty", None) if metadata is not None else None
+    vector = None
+    if include_vector and obj.vector:
+        vector = obj.vector.get("default") if isinstance(obj.vector, dict) else obj.vector
+    return StoreRecord(
+        uuid=str(obj.uuid),
+        properties=dict(obj.properties or {}),
+        vector=vector,
+        distance=distance,
+        certainty=certainty,
+    )
+
+
+_DATA_TYPE_MAP = {
+    "TEXT": wvc.DataType.TEXT,
+    "INT": wvc.DataType.INT,
+    "NUMBER": wvc.DataType.NUMBER,
+    "BOOL": wvc.DataType.BOOL,
+    "DATE": wvc.DataType.DATE,
+    "UUID": wvc.DataType.UUID,
+    "TEXT_ARRAY": wvc.DataType.TEXT_ARRAY,
+}
+
+
+_TOKENIZATION_MAP = {
+    "word": Tokenization.WORD,
+    "whitespace": Tokenization.WHITESPACE,
+    "field": Tokenization.FIELD,
+    "lowercase": Tokenization.LOWERCASE,
+}
+
+
+class WeaviateVectorStore(VectorStore):
+    """Adapter around an existing weaviate.WeaviateClient instance.
+
+    Construction is lazy via ``WeaviateVectorStore(client=...)`` from the
+    factory; passing the cached client preserves the singleton semantics
+    the rest of the package relies on.
+    """
+
+    backend_name = "weaviate"
+
+    def __init__(self, client: weaviate.WeaviateClient):
+        self._client = client
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def is_ready(self) -> bool:
+        try:
+            return bool(self._client.is_ready())
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def collection_exists(self, collection: str) -> bool:
+        return self._client.collections.exists(collection)
+
+    def ensure_collection(
+        self,
+        collection: str,
+        properties: List[Dict[str, Any]],
+        vector_dim: Optional[int] = None,
+    ) -> None:
+        if self._client.collections.exists(collection):
+            return
+        wvc_props = []
+        for p in properties:
+            dtype = _DATA_TYPE_MAP.get(p["data_type"].upper())
+            if dtype is None:
+                raise ValueError(f"Unsupported data_type '{p['data_type']}' on '{p['name']}'")
+            tok_str = p.get("tokenization")
+            tok = _TOKENIZATION_MAP.get(tok_str.lower()) if tok_str else None
+            wvc_props.append(
+                wvc.Property(
+                    name=p["name"],
+                    data_type=dtype,
+                    description=p.get("description"),
+                    tokenization=tok,
+                )
+            )
+        self._client.collections.create(
+            name=collection,
+            properties=wvc_props,
+            vector_config=wvc.Configure.Vectors.self_provided(),
+        )
+
+    def delete_collection(self, collection: str) -> None:
+        if self._client.collections.exists(collection):
+            self._client.collections.delete(collection)
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def insert(
+        self,
+        collection: str,
+        properties: Dict[str, Any],
+        uuid: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+    ) -> str:
+        col = self._client.collections.get(collection)
+        kwargs: Dict[str, Any] = {"properties": properties}
+        if uuid:
+            kwargs["uuid"] = uuid
+        if vector is not None:
+            kwargs["vector"] = vector
+        return str(col.data.insert(**kwargs))
+
+    def insert_many(self, collection: str, items: List[Dict[str, Any]]) -> int:
+        if not items:
+            return 0
+        # Use the dynamic batch context for efficient bulk writes.
+        try:
+            with self._client.batch.dynamic() as batch:
+                for item in items:
+                    batch.add_object(
+                        collection=item.get("collection", collection),
+                        properties=item["properties"],
+                        uuid=item.get("uuid"),
+                        vector=item.get("vector"),
+                    )
+            failed = getattr(self._client.batch, "failed_objects", []) or []
+            for f in failed:
+                logger.error("Batch insert failed for one item: %s", getattr(f, "message", f))
+            return len(items) - len(failed)
+        except RuntimeError:
+            return 0
+        except Exception as e:
+            msg = str(e).lower()
+            if "shutdown" in msg or "closed" in msg:
+                return 0
+            logger.error("insert_many error: %s", e)
+            return 0
+
+    def update(self, collection: str, uuid: str, properties: Dict[str, Any]) -> None:
+        col = self._client.collections.get(collection)
+        col.data.update(uuid=uuid, properties=properties)
+
+    def delete_by_filter(self, collection: str, filters: Dict[str, Any]) -> int:
+        if not filters:
+            return 0
+        col = self._client.collections.get(collection)
+        wf = _build_weaviate_filter(filters)
+        if wf is None:
+            return 0
+        result = col.data.delete_many(where=wf)
+        return int(getattr(result, "successful", 0) or 0)
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def fetch_by_id(
+        self,
+        collection: str,
+        uuid: str,
+        include_vector: bool = False,
+    ) -> Optional[StoreRecord]:
+        col = self._client.collections.get(collection)
+        try:
+            obj = col.query.fetch_object_by_id(uuid=uuid, include_vector=include_vector)
+        except Exception as e:
+            logger.warning("fetch_by_id failed for %s/%s: %s", collection, uuid, e)
+            return None
+        if obj is None:
+            return None
+        return _to_record(obj, include_vector=include_vector)
+
+    def query(
+        self,
+        collection: str,
+        filters: Optional[Dict[str, Any]] = None,
+        sort_by: Optional[str] = None,
+        sort_ascending: bool = False,
+        limit: int = 10,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        col = self._client.collections.get(collection)
+        wf = _build_weaviate_filter(filters)
+        sort = None
+        if sort_by:
+            sort = wvc_query.Sort.by_property(name=sort_by, ascending=sort_ascending)
+        kwargs: Dict[str, Any] = {"limit": limit, "filters": wf, "sort": sort}
+        if return_properties:
+            kwargs["return_properties"] = return_properties
+        response = col.query.fetch_objects(**kwargs)
+        return [_to_record(o) for o in response.objects]
+
+    def near_vector(
+        self,
+        collection: str,
+        vector: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        certainty: Optional[float] = None,
+        limit: int = 1,
+        include_vector: bool = False,
+        return_properties: Optional[List[str]] = None,
+    ) -> List[StoreRecord]:
+        col = self._client.collections.get(collection)
+        wf = _build_weaviate_filter(filters)
+        kwargs: Dict[str, Any] = {
+            "near_vector": vector,
+            "limit": limit,
+            "filters": wf,
+            "return_metadata": wvc_query.MetadataQuery(distance=True, certainty=True),
+            "include_vector": include_vector,
+        }
+        if certainty is not None:
+            kwargs["certainty"] = certainty
+        if return_properties:
+            kwargs["return_properties"] = return_properties
+        response = col.query.near_vector(**kwargs)
+        return [_to_record(o, include_vector=include_vector) for o in response.objects]
+
+    def iterate(self, collection: str, batch_size: int = 100) -> Iterable[StoreRecord]:
+        col = self._client.collections.get(collection)
+        for obj in col.iterator():
+            yield _to_record(obj)


### PR DESCRIPTION
Closes (or addresses the bulk of) #95.

## Summary

Adds a Docker-less Lite mode so hackathon / Colab / quick-demo users can `pip install vectorwave[lite]` and start logging immediately, without changing anything for production users.

The implementation introduces a backend-agnostic `VectorStore` interface and ships two backends — Weaviate (existing logic, default) and LanceDB (new, file-based). Mode is selected by `VECTORWAVE_MODE` env (`pro` or `lite`).

## Why not the full Repository-Pattern refactor proposed in the issue

Existing comment on #95 already explains: 22+ files reach into Weaviate APIs and full ChromaDB/LanceDB feature parity is hard. This PR takes the middle path:

1. **Build the abstraction once**, in `vectorwave/store/`.
2. **Migrate the highest-value paths first** (batch flush + execution search) so a useful `@vectorize` end-to-end flow works in Lite mode.
3. **Leave the rest untouched** — Pro mode behaves identically because the new abstraction is opt-in. Remaining call sites keep working with Weaviate and become future-PR work as they prove necessary.

Result: real Lite mode value today, no breakage for Pro users.

## Changes

### New: `src/vectorwave/store/`
- `base.py` — `VectorStore` ABC + `StoreRecord` dataclass. Operations: `is_ready`, `close`, `collection_exists`, `ensure_collection`, `delete_collection`, `insert`, `insert_many`, `update`, `delete_by_filter`, `fetch_by_id`, `query`, `near_vector`, `iterate`.
- `weaviate_store.py` — adapter that wraps the existing `weaviate.WeaviateClient` instance. Preserves `client.batch.dynamic()` for bulk inserts so Pro perf is unchanged.
- `lance_store.py` — local file-based store at `.vectorwave/lance/` (override via `VECTORWAVE_LITE_PATH`). Per-collection schema is `(uuid, vector<float32, 384>, payload<JSON>)`. Filter operators are evaluated in Python after fetch — fine for the Lite use case (≤100k rows).
- `factory.py` — `get_vector_store()` lru_cache singleton, picks Lite or Pro based on `VECTORWAVE_MODE`.

### Wiring (minimal, surgical)
- `batch/batch.py` — adds `_lite_mode` flag set from env; Lite skips `_connect_client`'s Weaviate path and `_flush_batch_core` routes through `_flush_via_store` (groups items by collection → `store.insert_many`). Pro path is unchanged.
- `database/db_search.py:search_executions` — now uses `store.query`. Translates to the same shape both backends accept. Pro behaviour preserved.

### Dependencies
- `pyproject.toml`: new `[lite]` extra (`lancedb>=0.30.0`); also added to `[dev]` so the test suite can exercise both backends.

## What's NOT in Lite mode (yet)

Still Pro-only:
- Hybrid search (`search_functions_hybrid`) — needs BM25 + vector fusion which LanceDB exposes differently
- Weaviate's modular vectorizers (`text2vec-openai` etc.) — Lite always uses a Python-side vectorizer
- Drift detection (`check_semantic_drift`) — relies on Weaviate's distance/certainty semantics that LanceDB approximates
- Advanced search call sites (`db_search.search_functions`, `dataset.recommend_candidates`, `replayer`, `archiver`, `healer`) — keep working in Pro; ports staged for follow-up PRs

The `@vectorize` core flow (decorate → execute → log → filter/sort fetch via `find_executions`) works in Lite today.

## Test Results

```
141 passed, 8 skipped (benchmarks), 1 warning in 144s
```

3 new e2e tests in `src/tests/test_lite_mode.py` against a real LanceDB tmp dir (no Docker):
- A decorated call lands in LanceDB
- `find_executions` filters by status across SUCCESS / ERROR rows
- Lite-mode calls must never invoke `get_weaviate_client`

Existing 138 tests keep passing — Pro mode is unchanged.

## Docs

`CONTRIBUTING.md` gains a *Modes: Pro vs Lite* section listing when to pick each and what's currently supported.

## Try it

```bash
pip install -e ".[lite]"
export VECTORWAVE_MODE=lite
python - <<'PY'
from vectorwave import vectorize
@vectorize(search_description="hello", sequence_narrative="demo")
def add(a, b): return a + b
print(add(1, 2))  # 3 — and it logs to ./.vectorwave/lance/
PY
```