### PR TITLE
feat(store): finish Lite mode coverage across read/write paths

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -33,14 +33,32 @@ interface (`src/vectorwave/store/`). Two backends ship today:
 | `lite` | LanceDB local file store | `VECTORWAVE_MODE=lite` | hackathons, Colab, quick demos — no Docker |
 
 In Lite mode VectorWave writes to `.vectorwave/lance/` (override with
-`VECTORWAVE_LITE_PATH`) and works offline with `pip install vectorwave`
+`VECTORWAVE_LITE_PATH`) and works offline with `pip install vectorwave[lite]`
 plus a Python-side vectorizer (default: HuggingFace `all-MiniLM-L6-v2`).
 
-Lite mode currently supports the core `@vectorize` flow: function
-metadata, execution logs, basic filter/sort fetch via
-`find_executions`, and vector cache lookup. Hybrid search and Weaviate's
-modular vectorizers (`text2vec-openai` etc.) remain Pro-only — see
-issue #95 for the migration roadmap.
+What works in each mode:
+
+| Feature | Pro | Lite |
+|---|---|---|
+| `@vectorize` decorator, log to executions collection | ✅ | ✅ |
+| `find_executions` / `search_executions` (filter + sort) | ✅ | ✅ |
+| `search_functions` (Python-vectorizer-driven `near_vector`) | ✅ | ✅ |
+| `search_errors_by_message` (near_vector + filter) | ✅ | ✅ |
+| `search_similar_execution` (semantic cache lookup) | ✅ | ✅ |
+| `@vectorize(semantic_cache=True)` end-to-end | ✅ | ✅ |
+| `check_semantic_drift` (KNN-based) | ✅ | ✅ |
+| `get_token_usage_stats` | ✅ | ✅ |
+| `VectorWaveArchiver` (export + clear) | ✅ | ✅ |
+| `VectorWaveDatasetManager` (golden register + recommend) | ✅ | ✅ |
+| `VectorWaveReplayer` (golden-first replay) | ✅ | ✅ |
+| `VectorWaveHealer` (LLM-driven self-healing) | ✅ | ✅ |
+| `search_functions_hybrid` (BM25 + vector hybrid) | ✅ | ❌ Pro-only |
+| Weaviate vectorizer modules (`text2vec-openai` etc.) | ✅ | ❌ Pro-only |
+| Multi-tenancy, server-side replication | ✅ | ❌ Pro-only |
+
+Lite uses Python-side filtering (a fetch + Python filter), which is fine
+at hackathon / Colab scale (≲100k rows). For multi-million-row production
+workloads, use Pro mode (Weaviate ANN + indexed filters).
 
 ## OpenTelemetry export
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -112,7 +112,17 @@ def _clear_vectorwave_singletons():
     from vectorwave.database.db import get_cached_client
     from vectorwave.vectorizer.factory import get_vectorizer
     from vectorwave.batch.batch import get_batch_manager as _gbm
-    for fn in (get_weaviate_settings, get_cached_client, get_vectorizer, _gbm):
+    # Also drop the VectorStore singleton — Lite-mode tests that ran earlier
+    # cache a LanceVectorStore here, which would silently serve Pro-mode
+    # `store.query` calls against an empty LanceDB and break the e2e suite.
+    try:
+        from vectorwave.store.factory import get_vector_store
+    except ImportError:
+        get_vector_store = None
+    targets = [get_weaviate_settings, get_cached_client, get_vectorizer, _gbm]
+    if get_vector_store is not None:
+        targets.append(get_vector_store)
+    for fn in targets:
         if hasattr(fn, "cache_clear"):
             fn.cache_clear()
 
@@ -197,9 +207,19 @@ def weaviate_container():
 
 
 @pytest.fixture
-def clean_weaviate(weaviate_container):
-    """Function-scoped fixture: deletes VectorWave collections before and after each test."""
+def clean_weaviate(weaviate_container, monkeypatch):
+    """Function-scoped fixture: deletes VectorWave collections before and after each test.
+
+    Also forces VECTORWAVE_MODE=pro and drops the VectorStore singleton so a
+    Lite-mode test that ran earlier in the session doesn't leave a cached
+    LanceVectorStore in place — it would silently serve `store.query` calls
+    against an empty LanceDB and make Pro-mode e2e assertions fail.
+    """
     from vectorwave.database.db import get_weaviate_client
+    from vectorwave.store.factory import get_vector_store
+
+    monkeypatch.setenv("VECTORWAVE_MODE", "pro")
+    get_vector_store.cache_clear()
 
     def _wipe():
         client = get_weaviate_client()

--- a/src/tests/test_lite_mode.py
+++ b/src/tests/test_lite_mode.py
@@ -143,3 +143,125 @@ def test_lite_mode_does_not_touch_weaviate(lite_mode_env, monkeypatch):
     # Allow the batch worker thread to drain.
     time.sleep(0.5)
     assert calls == [], f"Lite mode unexpectedly called Weaviate: {calls}"
+
+
+# ---------------------------------------------------------------------------
+# Extended Lite coverage — proves the migrated paths (archiver, dataset,
+# replayer, semantic-cache search helpers) work end-to-end without Weaviate.
+# ---------------------------------------------------------------------------
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from vectorwave.database.archiver import VectorWaveArchiver
+from vectorwave.database.dataset import VectorWaveDatasetManager
+from vectorwave.database.db_search import (
+    search_similar_execution,
+    check_semantic_drift,
+)
+from vectorwave.utils.replayer import VectorWaveReplayer
+
+
+def _seed_row(store, settings, *, function_name, return_value, vector=None, status="SUCCESS"):
+    return store.insert(
+        collection=settings.EXECUTION_COLLECTION_NAME,
+        properties={
+            "function_uuid": str(uuid4()),
+            "function_name": function_name,
+            "status": status,
+            "duration_ms": 1.0,
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "return_value": json.dumps(return_value) if not isinstance(return_value, str) else return_value,
+        },
+        vector=vector,
+    )
+
+
+def test_lite_mode_archiver_export_and_clear(lite_mode_env, tmp_path):
+    """archiver.export_and_clear writes JSONL and removes rows in Lite mode."""
+    settings = lite_mode_env
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+
+    for v in ["a", "b"]:
+        _seed_row(store, settings, function_name="lite_arch", return_value=v)
+
+    out = tmp_path / "out" / "data.jsonl"
+    archiver = VectorWaveArchiver()
+    result = archiver.export_and_clear(
+        function_name="lite_arch",
+        output_file=str(out),
+        clear_after_export=True,
+    )
+    assert result["exported"] == 2
+    assert result["deleted"] == 2
+    assert out.exists()
+
+
+def test_lite_mode_dataset_register_as_golden(lite_mode_env):
+    """register_as_golden copies a SUCCESS log + its vector into the golden collection."""
+    settings = lite_mode_env
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+    store.ensure_collection(settings.GOLDEN_COLLECTION_NAME, properties=[])
+
+    uuid_str = _seed_row(
+        store, settings, function_name="lite_golden",
+        return_value="r1", vector=[0.1] * 384,
+    )
+
+    manager = VectorWaveDatasetManager()
+    assert manager.register_as_golden(uuid_str, note="lite test") is True
+
+    golden_rows = store.query(settings.GOLDEN_COLLECTION_NAME, limit=10)
+    assert len(golden_rows) == 1
+    assert golden_rows[0].properties.get("original_uuid") == uuid_str
+
+
+def test_lite_mode_search_similar_execution(lite_mode_env):
+    """search_similar_execution finds the nearest SUCCESS row for a function."""
+    settings = lite_mode_env
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+
+    # `return_value=` is passed as already-stringified, so _seed_row stores "hit"
+    # verbatim (not JSON-encoded). That's the on-disk shape we read back.
+    _seed_row(store, settings, function_name="lite_cache", return_value="hit", vector=[1.0] * 384)
+
+    result = search_similar_execution(
+        query_vector=[1.0] * 384,
+        function_name="lite_cache",
+        threshold=0.5,
+        limit=1,
+    )
+    assert result is not None
+    assert result["return_value"] == "hit"
+
+
+def test_lite_mode_check_semantic_drift_returns_safely(lite_mode_env):
+    """drift detection: returns False/None safely when no matching rows exist
+    and runs through the store cleanly when rows are present."""
+    settings = lite_mode_env
+    from vectorwave.store import get_vector_store
+    store = get_vector_store()
+
+    is_drift, avg_dist, nearest = check_semantic_drift(
+        vector=[0.0] * 384,
+        function_name="nonexistent_fn",
+        threshold=0.5,
+        k=5,
+    )
+    assert is_drift is False
+    assert avg_dist == 0.0
+    assert nearest is None
+
+    _seed_row(store, settings, function_name="lite_drift", return_value="ok", vector=[1.0] * 384)
+    is_drift2, avg_dist2, nearest2 = check_semantic_drift(
+        vector=[1.0] * 384,
+        function_name="lite_drift",
+        threshold=10.0,
+        k=5,
+    )
+    assert is_drift2 is False
+    assert nearest2 is not None

--- a/src/tests/utils/test_replay_source.py
+++ b/src/tests/utils/test_replay_source.py
@@ -32,10 +32,13 @@ def mock_replay_deps(monkeypatch):
     mock_client.collections.get.return_value = mock_collection
     mock_get_client = MagicMock(return_value=mock_client)
 
-    # --- [수정] Patch dependencies where they are USED, not just defined ---
+    # --- Patch dependencies where they are USED ---
 
-    # 1. Patch for Replayer (vectorwave/utils/replayer.py)
-    monkeypatch.setattr("vectorwave.utils.replayer.get_cached_client", mock_get_client)
+    # 1. Replayer now uses VectorStore — patch the factory instead of get_cached_client.
+    mock_store = MagicMock()
+    mock_store.query.return_value = []
+    mock_store.fetch_by_id.return_value = None
+    monkeypatch.setattr("vectorwave.utils.replayer.get_vector_store", MagicMock(return_value=mock_store))
     monkeypatch.setattr("vectorwave.utils.replayer.get_weaviate_settings", mock_get_settings)
 
     # 2. Patch for Database (vectorwave/database/db.py) - 안전장치
@@ -90,20 +93,27 @@ def test_execution_source_tagging(mock_replay_deps):
     # ---------------------------------------------------------
     print("\n🔄 2. Running Replay...")
 
-    # Prepare dummy log for Replayer to fetch
-    dummy_log_obj = MagicMock()
-    dummy_log_obj.uuid = "old-uuid-123"
-    dummy_log_obj.properties = {
-        "function_name": "calc_add",
-        "a": 10,
-        "b": 20,
-        "return_value": "30",
-        "exec_source": "REALTIME"
-    }
+    # Prepare a dummy StoreRecord for the replayer to fetch via VectorStore.
+    from vectorwave.store.base import StoreRecord
+    dummy_record = StoreRecord(
+        uuid="old-uuid-123",
+        properties={
+            "function_name": "calc_add",
+            "a": 10,
+            "b": 20,
+            "return_value": "30",
+            "exec_source": "REALTIME",
+        },
+    )
 
-    # Replayer uses client.collections.get().query.fetch_objects()
-    mock_collection = mock_replay_deps["client"].collections.get.return_value
-    mock_collection.query.fetch_objects.return_value.objects = [dummy_log_obj]
+    # Replayer now uses store.query for the standard executions path. Golden
+    # returns empty so the standard branch fills the batch with our record.
+    from vectorwave.utils import replayer as replayer_mod
+    store = replayer_mod.get_vector_store()
+    store.query.side_effect = [
+        [],            # golden lookup → empty
+        [dummy_record], # standard executions → one match
+    ]
 
     # Also need to mock import_module since Replayer imports the function dynamically
     with patch("vectorwave.utils.replayer.importlib.import_module") as mock_import:

--- a/src/tests/utils/test_return_caching.py
+++ b/src/tests/utils/test_return_caching.py
@@ -52,50 +52,40 @@ def mock_caching_utils_deps(monkeypatch):
 def mock_caching_utils_deps_v2(monkeypatch):
     """
     Enhanced Mock Fixture for Golden Dataset testing.
-    Mocks Client, Golden Collection, and Standard Search.
+    Mocks VectorStore (golden hit/miss), search_similar_execution, vectorizer, batch.
     """
-    # Settings Mock
     mock_settings = WeaviateSettings(
         EXECUTION_COLLECTION_NAME="Executions",
         GOLDEN_COLLECTION_NAME="GoldenData"
     )
     mock_get_settings = MagicMock(return_value=mock_settings)
 
-    # Client & Golden Collection Mock
-    mock_client = MagicMock()
-    mock_golden_col = MagicMock()
+    # Backend-agnostic VectorStore mock — golden hits go through store.near_vector
+    mock_store = MagicMock()
+    mock_store.near_vector.return_value = []  # default: golden miss
+    mock_get_store = MagicMock(return_value=mock_store)
 
-    def get_collection_side_effect(name):
-        if name == "GoldenData": return mock_golden_col
-        return MagicMock()
-
-    mock_client.collections.get.side_effect = get_collection_side_effect
-    mock_get_client = MagicMock(return_value=mock_client)
-
-    # Vectorizer Mock
     mock_vectorizer = MagicMock()
     mock_vectorizer.embed.return_value = [0.1, 0.2]
     mock_get_vectorizer = MagicMock(return_value=mock_vectorizer)
 
-    # Batch Mock
     mock_batch = MagicMock()
     mock_get_batch = MagicMock(return_value=mock_batch)
 
-    # Patching
     TARGET = "vectorwave.utils.return_caching_utils"
     monkeypatch.setattr(f"{TARGET}.get_weaviate_settings", mock_get_settings)
-    monkeypatch.setattr(f"{TARGET}.get_cached_client", mock_get_client)
+    monkeypatch.setattr(f"{TARGET}.get_vector_store", mock_get_store)
     monkeypatch.setattr(f"{TARGET}.get_vectorizer", mock_get_vectorizer)
     monkeypatch.setattr(f"{TARGET}.get_batch_manager", mock_get_batch)
 
-    # Important: Mock search_similar_execution (Standard Search)
+    # Mock search_similar_execution (standard search fallback)
     mock_search_std = MagicMock(return_value=None)
     monkeypatch.setattr(f"{TARGET}.search_similar_execution", mock_search_std)
 
     return {
-        "golden_col": mock_golden_col,
+        "store": mock_store,
         "search_std": mock_search_std,
-        "batch": mock_batch
+        "batch": mock_batch,
     }
 
 
@@ -112,12 +102,12 @@ def test_check_and_return_cached_result_cache_hit_logging(mock_caching_utils_dep
         "uuid": "cached-log-uuid"
     }
 
-    # [NEW] Mock Client for Golden Dataset check (Return empty -> fall through to search_similar_execution)
-    mock_client = MagicMock()
-    mock_client.collections.get.return_value.query.near_vector.return_value.objects = []
+    # Mock VectorStore so the Golden lookup returns nothing -> fall through to
+    # the standard `search_similar_execution` path.
+    mock_store = MagicMock()
+    mock_store.near_vector.return_value = []
 
-    # [FIX] Patch get_cached_client
-    with patch("vectorwave.utils.return_caching_utils.get_cached_client", return_value=mock_client):
+    with patch("vectorwave.utils.return_caching_utils.get_vector_store", return_value=mock_store):
         with patch("vectorwave.utils.return_caching_utils.search_similar_execution", return_value=mock_cached_log):
             with patch("vectorwave.utils.return_caching_utils.current_tracer_var") as mock_tracer_var:
                 with patch("vectorwave.utils.return_caching_utils.current_span_id_var") as mock_span_var:
@@ -167,12 +157,16 @@ def test_cache_priority_golden_hit(mock_caching_utils_deps_v2):
     """
     deps = mock_caching_utils_deps_v2
 
-    # Arrange: Golden search result exists (Hit)
-    mock_obj = MagicMock()
-    mock_obj.properties = {"return_value": '"GoldenResult"', "original_uuid": "orig-1"}
-    mock_obj.metadata.distance = 0.0
-    mock_obj.metadata.certainty = 1.0
-    deps["golden_col"].query.near_vector.return_value.objects = [mock_obj]
+    # Arrange: VectorStore golden lookup returns a StoreRecord (hit)
+    from vectorwave.store.base import StoreRecord
+    deps["store"].near_vector.return_value = [
+        StoreRecord(
+            uuid="golden-1",
+            properties={"return_value": '"GoldenResult"', "original_uuid": "orig-1"},
+            distance=0.0,
+            certainty=1.0,
+        )
+    ]
 
     # Act
     result = _check_and_return_cached_result(
@@ -181,9 +175,9 @@ def test_cache_priority_golden_hit(mock_caching_utils_deps_v2):
 
     # Assert
     assert result == "GoldenResult"
-    # Check if Golden Collection search was called
-    deps["golden_col"].query.near_vector.assert_called_once()
-    # Standard search (search_similar_execution) should not be called (Verify Priority Logic)
+    # Golden lookup was called
+    deps["store"].near_vector.assert_called_once()
+    # Standard search should not be called (Verify Priority Logic)
     deps["search_std"].assert_not_called()
 
 
@@ -193,10 +187,9 @@ def test_cache_priority_golden_miss_fallback(mock_caching_utils_deps_v2):
     """
     deps = mock_caching_utils_deps_v2
 
-    # Arrange: No result in Golden search (Miss)
-    deps["golden_col"].query.near_vector.return_value.objects = []
+    # Arrange: Golden returns empty -> fallback to standard search
+    deps["store"].near_vector.return_value = []
 
-    # Set Standard search result (Hit)
     deps["search_std"].return_value = {
         "return_value": '"StdResult"',
         "metadata": {"distance": 0.1, "certainty": 0.9},
@@ -211,5 +204,5 @@ def test_cache_priority_golden_miss_fallback(mock_caching_utils_deps_v2):
     # Assert
     assert result == "StdResult"
     # Both should have been called
-    deps["golden_col"].query.near_vector.assert_called_once()
+    deps["store"].near_vector.assert_called_once()
     deps["search_std"].assert_called_once()

--- a/src/vectorwave/database/archiver.py
+++ b/src/vectorwave/database/archiver.py
@@ -1,14 +1,14 @@
 import json
 import os
-from typing import Dict, Any, List
-import weaviate.classes.query as wvc_query  # Using Weaviate v4 filters
-from .db import get_cached_client           # Import within the same package
+from typing import Dict, Any
 from ..models.db_config import get_weaviate_settings
+from ..store import get_vector_store
+
 
 class VectorWaveArchiver:
     def __init__(self):
-        self.client = get_cached_client()
         self.settings = get_weaviate_settings()
+        self.store = get_vector_store()
         self.collection_name = self.settings.EXECUTION_COLLECTION_NAME
 
     def export_and_clear(self,
@@ -17,27 +17,24 @@ class VectorWaveArchiver:
                          clear_after_export: bool = False,
                          delete_only: bool = False) -> Dict[str, int]:
         """
-        Exports execution logs or cleans them up from the database.
+        Exports execution logs or cleans them up from the backend store.
+        Routes through the VectorStore interface so the same flow works in
+        Pro (Weaviate) and Lite (LanceDB) modes.
         """
-        collection = self.client.collections.get(self.collection_name)
-
-        # 1. Configure the filter
-        filters = wvc_query.Filter.by_property("function_name").equal(function_name)
-
-        # Filter only successful logs if it's for training export
+        # 1. Configure the filter. Non-delete-only mode also requires SUCCESS.
+        filters: Dict[str, Any] = {"function_name": function_name}
         if not delete_only:
-            filters = filters & wvc_query.Filter.by_property("status").equal("SUCCESS")
+            filters["status"] = "SUCCESS"
 
         # 2. Retrieve data
-        # UUID is automatically included in the fetch_objects result object (obj.uuid).
-        response = collection.query.fetch_objects(
+        records = self.store.query(
+            collection=self.collection_name,
             filters=filters,
             limit=10000,
-            return_properties=["return_value", "timestamp_utc"]
+            return_properties=["return_value", "timestamp_utc"],
         )
 
-        objects = response.objects
-        if not objects:
+        if not records:
             return {"exported": 0, "deleted": 0}
 
         exported_count = 0
@@ -51,38 +48,42 @@ class VectorWaveArchiver:
                 os.makedirs(os.path.dirname(output_file) or '.', exist_ok=True)
 
                 with open(output_file, 'a', encoding='utf-8') as f:
-                    for obj in objects:
-                        data_entry = self._convert_to_training_format(obj)
+                    for rec in records:
+                        data_entry = self._convert_to_training_format(rec)
                         f.write(json.dumps(data_entry, ensure_ascii=False) + "\n")
-                        uuids_to_delete.append(obj.uuid)
+                        uuids_to_delete.append(rec.uuid)
                         exported_count += 1
                 print(f"✅ [Export] {exported_count} records saved: {output_file}")
             except Exception as e:
                 print(f"❌ [Error] Failed to save file: {e}")
-                return {"exported": 0, "deleted": 0} # Stop deletion upon save failure
+                return {"exported": 0, "deleted": 0}  # Stop deletion upon save failure
         else:
-            # If in delete-only mode, add all retrieved objects to the deletion list
-            uuids_to_delete = [obj.uuid for obj in objects]
+            # If in delete-only mode, every retrieved row goes to delete list
+            uuids_to_delete = [rec.uuid for rec in records]
 
-        # 4. Delete from DB (if option is enabled)
+        # 4. Delete from store (if option is enabled)
         if (clear_after_export or delete_only) and uuids_to_delete:
             try:
-                # Use Weaviate v4 delete_many
-                result = collection.data.delete_many(
-                    where=wvc_query.Filter.by_id().contains_any(uuids_to_delete)
+                deleted_count = self.store.delete_by_filter(
+                    collection=self.collection_name,
+                    filters=filters,
                 )
-                deleted_count = result.successful
-                print(f"🗑️ [Clear] {deleted_count} records deleted from DB.")
+                print(f"🗑️ [Clear] {deleted_count} records deleted.")
             except Exception as e:
-                print(f"❌ [Error] DB deletion failed: {e}")
+                print(f"❌ [Error] Delete failed: {e}")
 
         return {"exported": exported_count, "deleted": deleted_count}
 
-    def _convert_to_training_format(self, obj) -> Dict[str, Any]:
+    def _convert_to_training_format(self, rec) -> Dict[str, Any]:
         """
-        Converts logs to LLM fine-tuning format (JSONL)
+        Converts a StoreRecord (or any object with `.properties` + `.uuid`) into
+        an LLM fine-tuning JSONL row.
         """
-        props = obj.properties
+        # Accepts either a StoreRecord or a dict (for backwards compatibility).
+        if hasattr(rec, "properties"):
+            props = rec.properties
+        else:
+            props = rec
         exclude_keys = {
             'status', 'duration_ms', 'timestamp_utc', 'error_message', 'error_code',
             'return_value', 'function_name', 'trace_id', 'span_id', 'parent_span_id',

--- a/src/vectorwave/database/dataset.py
+++ b/src/vectorwave/database/dataset.py
@@ -1,15 +1,13 @@
 # src/vectorwave/database/dataset.py
 import logging
-import uuid
 import math
 from datetime import datetime, timezone
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
-import weaviate.classes.query as wvc_query
 from weaviate.util import generate_uuid5
 
-from .db import get_cached_client
 from ..models.db_config import get_weaviate_settings
+from ..store import get_vector_store
 
 logger = logging.getLogger(__name__)
 
@@ -18,46 +16,34 @@ class VectorWaveDatasetManager:
     """
     Manages the 'VectorWaveGoldenDataset' collection.
     Provides interfaces for registering golden data and recommending candidates based on vector density.
+
+    Routes through the VectorStore abstraction so the same code path works in
+    Pro (Weaviate) and Lite (LanceDB) modes.
     """
 
     def __init__(self):
-        self.client = get_cached_client()
         self.settings = get_weaviate_settings()
-        self.exec_col = self.client.collections.get(self.settings.EXECUTION_COLLECTION_NAME)
-        self.golden_col = self.client.collections.get(self.settings.GOLDEN_COLLECTION_NAME)
+        self.store = get_vector_store()
 
     def register_as_golden(self, log_uuid: str, note: str = "", tags: List[str] = None) -> bool:
         """
-        [Issue #78] Copies a specific execution log to the Golden Dataset.
+        Copies a specific execution log to the Golden Dataset, preserving the
+        original vector. Returns False if the source log is missing or has no
+        stored vector (capture_return_value=True is required upstream for the
+        log to carry one).
         """
         try:
-            # 1. Fetch original log (including vector)
-            log_obj = self.exec_col.query.fetch_object_by_id(
+            log_rec = self.store.fetch_by_id(
+                collection=self.settings.EXECUTION_COLLECTION_NAME,
                 uuid=log_uuid,
-                include_vector=True
+                include_vector=True,
             )
-
-            if log_obj is None:
+            if log_rec is None:
                 logger.error(f"Log UUID '{log_uuid}' not found.")
                 return False
 
-            props = log_obj.properties
-
-            # 2. Configure Golden Data properties
-            golden_props = {
-                "original_uuid": str(log_obj.uuid),
-                "function_name": props.get("function_name"),
-                "function_uuid": props.get("function_uuid"),
-                "return_value": props.get("return_value"),
-                "note": note,
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "tags": tags if tags else []
-            }
-
-            # 3. Save (reuse original vector). Weaviate v4's `self_provided`
-            # vectorizer returns an empty list (not None) when no vector was
-            # stored, so reject any falsy value.
-            vector = (log_obj.vector or {}).get("default")
+            props = log_rec.properties
+            vector = log_rec.vector
             if not vector:
                 logger.error(
                     f"Log '{log_uuid}' has no stored vector. "
@@ -65,10 +51,21 @@ class VectorWaveDatasetManager:
                 )
                 return False
 
-            self.golden_col.data.insert(
+            golden_props = {
+                "original_uuid": str(log_rec.uuid),
+                "function_name": props.get("function_name"),
+                "function_uuid": props.get("function_uuid"),
+                "return_value": props.get("return_value"),
+                "note": note,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "tags": tags if tags else [],
+            }
+
+            self.store.insert(
+                collection=self.settings.GOLDEN_COLLECTION_NAME,
                 properties=golden_props,
                 vector=vector,
-                uuid=generate_uuid5(log_uuid)  # Regenerate to avoid UUID collision, or maintain relation with original
+                uuid=generate_uuid5(log_uuid),
             )
             logger.info(f"✅ Registered log {log_uuid} as Golden Data.")
             return True
@@ -79,79 +76,76 @@ class VectorWaveDatasetManager:
 
     def recommend_candidates(self, function_name: str, limit: int = 5) -> List[Dict[str, Any]]:
         """
-        [Issue #80] Density-Based Recommendation Logic.
+        Density-Based Recommendation Logic.
         Analyzes the vector distribution of existing Golden Data to suggest new candidates.
         """
-        # 1. Fetch all vectors from Golden Data
-        golden_objs = self.golden_col.query.fetch_objects(
-            filters=wvc_query.Filter.by_property("function_name").equal(function_name),
-            include_vector=True,
-            limit=1000
-        ).objects
+        # 1. Fetch all Golden entries for the function, then refetch with vectors.
+        golden_records = self.store.query(
+            collection=self.settings.GOLDEN_COLLECTION_NAME,
+            filters={"function_name": function_name},
+            limit=1000,
+        )
+        golden_with_vectors = []
+        for rec in golden_records:
+            full = self.store.fetch_by_id(
+                self.settings.GOLDEN_COLLECTION_NAME, rec.uuid, include_vector=True
+            )
+            if full and full.vector:
+                golden_with_vectors.append(full)
 
-        if not golden_objs:
+        if not golden_with_vectors:
             logger.info("No Golden Data found. Cannot calculate density.")
             return []
 
         # 2. Calculate Centroid and Density (Average Distance)
-        vectors = [obj.vector["default"] for obj in golden_objs]
-        if not vectors: return []
+        vectors = [rec.vector for rec in golden_with_vectors]
+        if not vectors:
+            return []
 
-        dim = len(vectors[0])
         centroid = [sum(col) / len(vectors) for col in zip(*vectors)]
-
-        # Calculate Euclidean distance between each vector and Centroid
-        distances = []
-        for v in vectors:
-            dist = math.dist(v, centroid)
-            distances.append(dist)
-
-        avg_distance = sum(distances) / len(distances)  # This becomes the 'reference density'
+        distances = [math.dist(v, centroid) for v in vectors]
+        avg_distance = sum(distances) / len(distances)
 
         logger.info(f"[{function_name}] Golden Density (Avg Dist): {avg_distance:.4f}")
 
-        # 3. Search candidates (successful cases from standard execution logs)
-        # Exclude logs already registered as Golden (Filtering by original_uuid is complex, so handle in memory)
-        candidates = self.exec_col.query.near_vector(
-            near_vector=centroid,  # Fetch closest to centroid first
+        # 3. Candidates: SUCCESS executions for this function, near the centroid.
+        candidates = self.store.near_vector(
+            collection=self.settings.EXECUTION_COLLECTION_NAME,
+            vector=centroid,
+            filters={"function_name": function_name, "status": "SUCCESS"},
             limit=limit * 5,
-            filters=(
-                    wvc_query.Filter.by_property("function_name").equal(function_name) &
-                    wvc_query.Filter.by_property("status").equal("SUCCESS")
-            ),
-            return_metadata=wvc_query.MetadataQuery(distance=True),
-            include_vector=True
-        ).objects
+            include_vector=True,
+        )
 
-        golden_origin_ids = {obj.properties.get("original_uuid") for obj in golden_objs}
+        golden_origin_ids = {rec.properties.get("original_uuid") for rec in golden_with_vectors}
 
-        recommendations = []
+        recommendations: List[Dict[str, Any]] = []
 
-        # 4. Classification Logic (Steady vs Discovery)
         steady_limit = avg_distance + self.settings.RECOMMENDATION_STEADY_MARGIN
         discovery_limit = steady_limit + self.settings.RECOMMENDATION_DISCOVERY_MARGIN
 
         for cand in candidates:
-            if str(cand.uuid) in golden_origin_ids:
+            if cand.uuid in golden_origin_ids:
                 continue
 
-            # Weaviate near_vector distance is usually Cosine Distance (0~2) or Euclidean
-            # Here, use the distance calculated directly with the Centroid
-            dist_to_centroid = math.dist(cand.vector["default"], centroid)
+            cand_vec = cand.vector
+            if cand_vec is None:
+                continue
+            dist_to_centroid = math.dist(cand_vec, centroid)
 
             rec_type = "IGNORE"
             if dist_to_centroid <= steady_limit:
-                rec_type = "STEADY"  # Steady: Located within existing data distribution
+                rec_type = "STEADY"
             elif steady_limit < dist_to_centroid <= discovery_limit:
-                rec_type = "DISCOVERY"  # Discovery: Slightly outside existing distribution (Potential new pattern)
+                rec_type = "DISCOVERY"
 
             if rec_type != "IGNORE":
                 recommendations.append({
-                    "uuid": str(cand.uuid),
+                    "uuid": cand.uuid,
                     "type": rec_type,
                     "distance_to_center": dist_to_centroid,
                     "avg_density": avg_distance,
-                    "return_value": cand.properties.get("return_value")
+                    "return_value": cand.properties.get("return_value"),
                 })
 
             if len(recommendations) >= limit:

--- a/src/vectorwave/database/db_search.py
+++ b/src/vectorwave/database/db_search.py
@@ -14,7 +14,6 @@ from weaviate.classes.query import Filter
 _PROP_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 from ..models.db_config import get_weaviate_settings, WeaviateSettings
-from .db import get_cached_client
 from ..exception.exceptions import WeaviateConnectionError
 from ..vectorizer.factory import get_vectorizer
 from weaviate.classes.aggregate import Metrics
@@ -84,28 +83,24 @@ def search_errors_by_message(
         limit: int = 5,
         filters: Optional[Dict[str, Any]] = None
 ) -> List[Dict[str, Any]]:
-    # ... (No changes needed here)
     """
-    [NEW] Searches the 'VectorWaveExecutions' collection for
-    semantically similar error logs using a natural language query.
+    Searches the executions collection for semantically similar error logs.
+    Routes through the VectorStore so it works in both Pro and Lite modes.
     """
     try:
+        from ..store import get_vector_store
         settings: WeaviateSettings = get_weaviate_settings()
-        client: weaviate.WeaviateClient = get_cached_client()
+        store = get_vector_store()
 
-        collection = client.collections.get(settings.EXECUTION_COLLECTION_NAME)
-
-        # [NEW] By default, only search for logs with "ERROR" status
         base_filters = {"status": "ERROR"}
         if filters:
             base_filters.update(filters)
 
-        weaviate_filter = _build_weaviate_filters(base_filters)
-
         vectorizer = get_vectorizer()
         if vectorizer is None:
             logger.error(
-                "Cannot perform vector search: No Python vectorizer (e.g., 'huggingface' or 'openai_client') is configured in .env.")
+                "Cannot perform vector search: No Python vectorizer (huggingface / openai_client) configured."
+            )
             raise WeaviateConnectionError("Cannot perform vector search: No Python vectorizer configured.")
 
         try:
@@ -115,84 +110,64 @@ def search_errors_by_message(
             logger.error(f"Query vectorization failed: {e}")
             raise WeaviateConnectionError(f"Query vectorization failed: {e}")
 
-        logger.info(f"Performing near_vector search for errors matching: '{query}'")
-        response = collection.query.near_vector(
-            near_vector=query_vector,
+        records = store.near_vector(
+            collection=settings.EXECUTION_COLLECTION_NAME,
+            vector=query_vector,
+            filters=base_filters,
             limit=limit,
-            filters=weaviate_filter,
-            # [NEW] Return metadata (distance) along with properties useful for error analysis
-            return_metadata=wvc.query.MetadataQuery(distance=True),
             return_properties=[
                 "function_name", "error_message", "error_code",
-                "timestamp_utc", "trace_id", "parent_span_id", "span_id"
-            ]
+                "timestamp_utc", "trace_id", "parent_span_id", "span_id",
+            ],
         )
-
-        results = [
-            {
-                "properties": obj.properties,
-                "metadata": obj.metadata,
-                "uuid": obj.uuid
-            }
-            for obj in response.objects
+        return [
+            {"properties": r.properties, "metadata": {"distance": r.distance}, "uuid": r.uuid}
+            for r in records
         ]
-        return results
 
     except Exception as e:
-        logger.error("Error during Weaviate error search: %s", e)
+        logger.error("Error during error-message search: %s", e)
         raise WeaviateConnectionError(f"Failed to execute 'search_errors_by_message': {e}")
 
 
 def search_functions(query: str, limit: int = 5, filters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
-    # ... (No changes needed here)
     """
-    Searches function definitions from the [VectorWaveFunctions] collection using natural language (nearText).
+    Searches the functions collection. Requires a Python-side vectorizer
+    (HuggingFace / OpenAI client) so we always go through near_vector — the
+    legacy `near_text` path needed Weaviate's text2vec module, which Lite
+    mode doesn't have. Pro users without a Python vectorizer should set
+    VECTORIZER=huggingface (default) to keep using this function.
     """
     try:
+        from ..store import get_vector_store
         settings: WeaviateSettings = get_weaviate_settings()
-        client: weaviate.WeaviateClient = get_cached_client()
-
-        collection = client.collections.get(settings.COLLECTION_NAME)
-        weaviate_filter = _build_weaviate_filters(filters)
+        store = get_vector_store()
 
         vectorizer = get_vectorizer()
-
-        if vectorizer is not None:
-            print("[VectorWave] Searching with Python client (near_vector)...")
-            try:
-                query_vector = vectorizer.embed(query)
-            except Exception as e:
-                print(f"Error vectorizing query with Python client: {e}")
-                raise WeaviateConnectionError(f"Query vectorization failed: {e}")
-
-            response = collection.query.near_vector(
-                near_vector=query_vector,
-                limit=limit,
-                filters=weaviate_filter,
-                return_metadata=wvc.query.MetadataQuery(distance=True)
+        if vectorizer is None:
+            raise WeaviateConnectionError(
+                "search_functions requires a Python-side vectorizer. "
+                "Set VECTORIZER=huggingface (default) or 'openai_client'."
             )
 
-        else:
-            print("[VectorWave] Searching with Weaviate module (near_text)...")
-            response = collection.query.near_text(
-                query=query,
-                limit=limit,
-                filters=weaviate_filter,
-                return_metadata=wvc.query.MetadataQuery(distance=True)
-            )
+        try:
+            query_vector = vectorizer.embed(query)
+        except Exception as e:
+            raise WeaviateConnectionError(f"Query vectorization failed: {e}")
 
-        results = [
-            {
-                "properties": obj.properties,
-                "metadata": obj.metadata,
-                "uuid": obj.uuid
-            }
-            for obj in response.objects
+        records = store.near_vector(
+            collection=settings.COLLECTION_NAME,
+            vector=query_vector,
+            filters=filters,
+            limit=limit,
+        )
+        return [
+            {"properties": r.properties, "metadata": {"distance": r.distance}, "uuid": r.uuid}
+            for r in records
         ]
-        return results
 
     except Exception as e:
-        logger.error("Error during Weaviate search: %s", e)
+        logger.error("Error during function search: %s", e)
         raise WeaviateConnectionError(f"Failed to execute 'search_functions': {e}")
 
 
@@ -238,58 +213,51 @@ def search_similar_execution(
         function_name: str,
         threshold: float = 0.9,
         limit: int = 1,
-        filters: Optional[Dict[str, Any]] = None  # [NEW] 인자 추가
+        filters: Optional[Dict[str, Any]] = None
 ) -> Optional[Dict[str, Any]]:
     """
-    Searches the 'VectorWaveExecutions' collection with optional filters.
+    Searches the executions collection for the nearest SUCCESS log to a query
+    vector. Routes through the VectorStore so it works in both Pro and Lite.
     """
     try:
+        from ..store import get_vector_store
         settings: WeaviateSettings = get_weaviate_settings()
-        client: weaviate.WeaviateClient = get_cached_client()
-
-        collection = client.collections.get(settings.EXECUTION_COLLECTION_NAME)
+        store = get_vector_store()
 
         base_filters = {
             "status": "SUCCESS",
-            "function_name": function_name
+            "function_name": function_name,
         }
-
-        # [NEW] 사용자 필터 병합
         if filters:
             base_filters.update(filters)
 
-        weaviate_filter = _build_weaviate_filters(base_filters)
-
-        certainty_threshold = threshold
-
         logger.info(
-            f"Performing near_vector cache search for '{function_name}' with certainty >= {certainty_threshold}")
-
-        response = collection.query.near_vector(
-            near_vector=query_vector,
-            limit=limit,
-            filters=weaviate_filter,
-            certainty=certainty_threshold,
-            return_metadata=wvc.query.MetadataQuery(distance=True, certainty=True),
-            return_properties=["return_value", "timestamp_utc"]
+            f"Performing near_vector cache search for '{function_name}' with certainty >= {threshold}"
         )
 
-        if response.objects:
-            best_match = response.objects[0]
-            result = {
-                'return_value': best_match.properties.get('return_value'),
-                'metadata': {
-                    'distance': best_match.metadata.distance,
-                    'certainty': best_match.metadata.certainty,
-                },
-                'uuid': str(best_match.uuid)
-            }
-            return result
+        records = store.near_vector(
+            collection=settings.EXECUTION_COLLECTION_NAME,
+            vector=query_vector,
+            filters=base_filters,
+            certainty=threshold,
+            limit=limit,
+            return_properties=["return_value", "timestamp_utc"],
+        )
 
+        if records:
+            best = records[0]
+            return {
+                "return_value": best.properties.get("return_value"),
+                "metadata": {
+                    "distance": best.distance,
+                    "certainty": best.certainty,
+                },
+                "uuid": best.uuid,
+            }
         return None
 
     except Exception as e:
-        logger.error(f"Error during Weaviate cache search for '{function_name}': {e}", exc_info=True)
+        logger.error(f"Error during cache search for '{function_name}': {e}", exc_info=True)
         return None
 
 
@@ -299,11 +267,21 @@ def search_functions_hybrid(
         filters: Optional[Dict[str, Any]] = None,
         alpha: float = 0.5
 ) -> List[Dict[str, Any]]:
-    # ... (No changes needed here)
     """
     Performs Hybrid Search (Keyword + Vector) on function definitions.
+
+    **Pro-only.** Hybrid search (BM25 + vector with a tunable alpha) is a
+    Weaviate-specific feature; Lite mode (LanceDB) has no equivalent yet.
+    Lite users should call `search_functions` (pure vector) instead.
     """
+    import os
+    if os.environ.get("VECTORWAVE_MODE", "pro").lower() == "lite":
+        raise WeaviateConnectionError(
+            "search_functions_hybrid is a Pro-only feature. "
+            "Use search_functions for pure vector search in Lite mode."
+        )
     try:
+        from ..database.db import get_cached_client
         settings: WeaviateSettings = get_weaviate_settings()
         client: weaviate.WeaviateClient = get_cached_client()
 
@@ -364,41 +342,38 @@ def check_semantic_drift(
         threshold: float,
         k: int = 5
 ) -> Tuple[bool, float, Optional[str]]:
-    # ... (No changes needed here)
     """
-    KNN based semantic drift check.
+    KNN-based semantic drift check. Routes through the VectorStore so it works
+    in both Pro and Lite modes.
     """
     try:
+        from ..store import get_vector_store
         settings = get_weaviate_settings()
-        client = get_cached_client()
-        collection = client.collections.get(settings.EXECUTION_COLLECTION_NAME)
+        store = get_vector_store()
 
-        response = collection.query.near_vector(
-            near_vector=vector,
+        records = store.near_vector(
+            collection=settings.EXECUTION_COLLECTION_NAME,
+            vector=vector,
+            filters={"function_name": function_name, "status": "SUCCESS"},
             limit=k,
-            filters=(
-                    wvc.query.Filter.by_property("function_name").equal(function_name) &
-                    wvc.query.Filter.by_property("status").equal("SUCCESS")
-            ),
-            return_metadata=wvc.query.MetadataQuery(distance=True),
-            return_properties=[]
+            return_properties=[],
         )
 
-        objects = response.objects
-        if not objects:
+        if not records:
             return False, 0.0, None
 
-        distances = [obj.metadata.distance for obj in objects]
+        distances = [r.distance for r in records if r.distance is not None]
+        if not distances:
+            return False, 0.0, None
+
         avg_distance = sum(distances) / len(distances)
-
-        nearest_uuid = str(objects[0].uuid)
-
+        nearest_uuid = records[0].uuid
         is_drift = avg_distance > threshold
 
         if is_drift:
             logger.warning(
                 f"🚨 [Semantic Drift] '{function_name}' detected anomaly! "
-                f"Avg Distance (k={len(objects)}): {avg_distance:.4f} (Threshold: {threshold})"
+                f"Avg Distance (k={len(distances)}): {avg_distance:.4f} (Threshold: {threshold})"
             )
 
         return is_drift, avg_distance, nearest_uuid
@@ -462,21 +437,19 @@ def simulate_drift_check(
 
 
 def get_token_usage_stats() -> Dict[str, int]:
-    # ... (No changes needed here)
-    """VectorWaveTokenUsage collections based analysis"""
+    """VectorWaveTokenUsage collection based analysis. Works in both modes."""
     try:
-        client = get_cached_client()
-        if not client.collections.exists("VectorWaveTokenUsage"):
+        from ..store import get_vector_store
+        store = get_vector_store()
+        if not store.collection_exists("VectorWaveTokenUsage"):
             logger.warning("VectorWaveTokenUsage collection does not exist.")
             return {"total_tokens": 0}
 
-        usage_col = client.collections.get("VectorWaveTokenUsage")
-
         total_tokens = 0
-        stats = {}
+        stats: Dict[str, int] = {}
 
-        for obj in usage_col.iterator():
-            props = obj.properties
+        for rec in store.iterate("VectorWaveTokenUsage"):
+            props = rec.properties
             tokens = int(props.get("tokens", 0))
             category = props.get("category", "unknown")
 

--- a/src/vectorwave/utils/replayer.py
+++ b/src/vectorwave/utils/replayer.py
@@ -10,10 +10,8 @@ import pprint
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
-import weaviate.classes.query as wvc_query
-
-from ..database.db import get_cached_client
 from ..models.db_config import get_weaviate_settings
+from ..store import get_vector_store
 import vectorwave.vectorwave_core as vectorwave_core
 from .context import execution_source_context
 from .serialization import deserialize_return_value
@@ -50,7 +48,7 @@ class VectorWaveReplayer:
     """
 
     def __init__(self):
-        self.client = get_cached_client()
+        self.store = get_vector_store()
         self.settings = get_weaviate_settings()
         self.collection_name = self.settings.EXECUTION_COLLECTION_NAME
         self.golden_collection_name = self.settings.GOLDEN_COLLECTION_NAME
@@ -194,36 +192,35 @@ class VectorWaveReplayer:
         """
         candidates = []
 
-        # 2-1. Fetch from Golden Dataset
-        golden_col = self.client.collections.get(self.golden_collection_name)
-        exec_col = self.client.collections.get(self.collection_name)
-
+        # 2-1. Fetch from Golden Dataset via the VectorStore.
         try:
-            golden_res = golden_col.query.fetch_objects(
-                filters=wvc_query.Filter.by_property("function_name").equal(func_short_name),
-                limit=limit
+            golden_records = self.store.query(
+                collection=self.golden_collection_name,
+                filters={"function_name": func_short_name},
+                limit=limit,
             )
 
-            for obj in golden_res.objects:
-                original_uuid = obj.properties.get("original_uuid")
+            for rec in golden_records:
+                original_uuid = rec.properties.get("original_uuid")
                 if not original_uuid:
                     continue
 
-                original_log = exec_col.query.fetch_object_by_id(original_uuid)
+                original_log = self.store.fetch_by_id(
+                    collection=self.collection_name, uuid=original_uuid
+                )
                 if original_log is None:
-                    logger.warning(f"Golden Data {obj.uuid} refers to missing log {original_uuid}. Skipping.")
+                    logger.warning(f"Golden Data {rec.uuid} refers to missing log {original_uuid}. Skipping.")
                     continue
 
                 candidates.append({
-                    "uuid": str(obj.uuid),
+                    "uuid": rec.uuid,
                     "inputs": original_log.properties,
-                    "expected_output": self._deserialize_value(obj.properties.get("return_value")),
-                    "is_golden": True
+                    "expected_output": self._deserialize_value(rec.properties.get("return_value")),
+                    "is_golden": True,
                 })
 
             if candidates:
                 logger.info(f"Loaded {len(candidates)} Golden Data test cases.")
-
         except Exception as e:
             logger.error(f"Failed to fetch Golden Data: {e}")
 
@@ -231,22 +228,19 @@ class VectorWaveReplayer:
         remaining = limit - len(candidates)
         if remaining > 0:
             try:
-                filters = (
-                        wvc_query.Filter.by_property("function_name").equal(func_short_name) &
-                        wvc_query.Filter.by_property("status").equal("SUCCESS")
-                )
-                exec_res = exec_col.query.fetch_objects(
-                    filters=filters,
+                exec_records = self.store.query(
+                    collection=self.collection_name,
+                    filters={"function_name": func_short_name, "status": "SUCCESS"},
+                    sort_by="timestamp_utc",
+                    sort_ascending=False,
                     limit=remaining,
-                    sort=wvc_query.Sort.by_property("timestamp_utc", ascending=False)
                 )
-
-                for obj in exec_res.objects:
+                for rec in exec_records:
                     candidates.append({
-                        "uuid": str(obj.uuid),
-                        "inputs": obj.properties,
-                        "expected_output": self._deserialize_value(obj.properties.get("return_value")),
-                        "is_golden": False
+                        "uuid": rec.uuid,
+                        "inputs": rec.properties,
+                        "expected_output": self._deserialize_value(rec.properties.get("return_value")),
+                        "is_golden": False,
                     })
             except Exception as e:
                 logger.error(f"Failed to fetch Standard Executions: {e}")
@@ -280,7 +274,6 @@ class VectorWaveReplayer:
 
     def _update_baseline_value(self, uuid_str: str, new_value: Any, is_golden: bool):
         collection_name = self.golden_collection_name if is_golden else self.collection_name
-        collection = self.client.collections.get(collection_name)
 
         processed_val = vectorwave_core.mask_and_serialize(new_value, [])
         try:
@@ -289,9 +282,10 @@ class VectorWaveReplayer:
             val_str = str(processed_val)
 
         try:
-            collection.data.update(
+            self.store.update(
+                collection=collection_name,
                 uuid=uuid_str,
-                properties={"return_value": str(val_str)}
+                properties={"return_value": str(val_str)},
             )
         except Exception as e:
             logger.error(f"Failed to update baseline for {uuid_str}: {e}")

--- a/src/vectorwave/utils/return_caching_utils.py
+++ b/src/vectorwave/utils/return_caching_utils.py
@@ -5,17 +5,15 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from weaviate.util import generate_uuid5
-import weaviate.classes.query as wvc_query
-from weaviate.classes.query import Filter
 
 from ..models.db_config import get_weaviate_settings, WeaviateSettings
 from ..monitoring.tracer import _create_input_vector_data, current_tracer_var, \
     current_span_id_var
 from .serialization import deserialize_return_value as _deserialize_return_value
-from ..database.db_search import search_similar_execution, _build_weaviate_filters
+from ..database.db_search import search_similar_execution
 from ..vectorizer.factory import get_vectorizer
 from ..batch.batch import get_batch_manager
-from ..database.db import get_cached_client
+from ..store import get_vector_store
 
 logger = logging.getLogger(__name__)
 
@@ -64,32 +62,29 @@ def _check_and_return_cached_result(
         input_vector = vectorizer.embed(input_vector_data['text'])
 
         # (C) Priority 1: Search Golden Dataset
-        client = get_cached_client()
+        store = get_vector_store()
         golden_match = None
 
+        golden_filters: Dict[str, Any] = {"function_name": function_name}
+        if filters:
+            golden_filters.update(filters)
+
         try:
-            golden_col = client.collections.get(settings.GOLDEN_COLLECTION_NAME)
-
-            base_filter_obj = wvc_query.Filter.by_property("function_name").equal(function_name)
-            extra_filter_obj = _build_weaviate_filters(filters)
-
-            final_filters = base_filter_obj
-            if extra_filter_obj:
-                final_filters = Filter.all_of([base_filter_obj, extra_filter_obj])
-
-            response = golden_col.query.near_vector(
-                near_vector=input_vector,
-                limit=1,
-                filters=final_filters,
+            golden_records = store.near_vector(
+                collection=settings.GOLDEN_COLLECTION_NAME,
+                vector=input_vector,
+                filters=golden_filters,
                 certainty=cache_threshold,
+                limit=1,
                 return_properties=["return_value", "original_uuid"],
-                return_metadata=wvc_query.MetadataQuery(distance=True, certainty=True)
             )
 
-            if response.objects:
-                golden_match = response.objects[0]
-                logger.info(f"🌟 [Golden Cache Hit] '{function_name}' found in Golden Dataset. (Distance: {golden_match.metadata.distance:.4f})")
-
+            if golden_records:
+                golden_match = golden_records[0]
+                logger.info(
+                    f"🌟 [Golden Cache Hit] '{function_name}' found in Golden Dataset. "
+                    f"(Distance: {golden_match.distance:.4f})"
+                )
         except Exception as e:
             logger.warning(f"Golden cache search failed: {e}")
 
@@ -99,12 +94,12 @@ def _check_and_return_cached_result(
 
         if golden_match:
             cached_log = {
-                'return_value': golden_match.properties.get('return_value'),
-                'metadata': {
-                    'distance': golden_match.metadata.distance,
-                    'certainty': golden_match.metadata.certainty,
+                "return_value": golden_match.properties.get("return_value"),
+                "metadata": {
+                    "distance": golden_match.distance,
+                    "certainty": golden_match.certainty,
                 },
-                'uuid': str(golden_match.uuid)
+                "uuid": golden_match.uuid,
             }
             is_golden_hit = True
         else:


### PR DESCRIPTION
Builds on PR #114 (initial Lite mode) to migrate every remaining Weaviate-direct call site to the VectorStore abstraction. After this PR, every VectorWave feature except hybrid search works in Lite mode (LanceDB) without a Weaviate container.

## What used to be Pro-only and is now both

| Feature | Status |
|---|---|
| `archiver.export_and_clear` | ✅ Lite |
| `dataset.register_as_golden` | ✅ Lite |
| `dataset.recommend_candidates` | ✅ Lite |
| `return_caching_utils` semantic cache (golden + standard lookup) | ✅ Lite |
| `db_search.search_similar_execution` | ✅ Lite |
| `db_search.search_functions` (Python-vectorizer path) | ✅ Lite |
| `db_search.search_errors_by_message` | ✅ Lite |
| `db_search.check_semantic_drift` | ✅ Lite |
| `db_search.get_token_usage_stats` | ✅ Lite |
| `replayer` (golden-first + baseline update) | ✅ Lite |
| `healer` (uses `search_functions` underneath — also works) | ✅ Lite (best-effort) |

## Still Pro-only (raises a clear error in Lite)

- `db_search.search_functions_hybrid` — hybrid (BM25 + vector) is a Weaviate-specific feature; LanceDB has no equivalent yet. Lite users should call `search_functions` (pure vector) instead. The function now raises `WeaviateConnectionError` with that guidance when `VECTORWAVE_MODE=lite`.
- Weaviate vectorizer modules (`text2vec-openai` etc.), multi-tenancy, server-side replication — architectural to the backend, won't migrate.

## Changes

### Migrated to `store.*`

- `archiver.export_and_clear` → `store.query` + `store.delete_by_filter`
- `dataset.register_as_golden` → `store.fetch_by_id(include_vector=True)` + `store.insert`
- `dataset.recommend_candidates` → `store.query` + `store.near_vector(include_vector=True)`
- `replayer._fetch_test_candidates` → `store.query` for both golden and standard buckets
- `replayer._update_baseline_value` → `store.update`
- `return_caching_utils._check_and_return_cached_result` golden lookup → `store.near_vector` (standard lookup still routes through `search_similar_execution` which is now also store-based)
- `db_search.search_similar_execution` → `store.near_vector` with `certainty`
- `db_search.search_functions` → `store.near_vector`. The legacy `near_text` branch is removed because it required Weaviate's `text2vec-*` module; both backends now uniformly require a Python-side vectorizer.
- `db_search.search_errors_by_message` → `store.near_vector`
- `db_search.check_semantic_drift` → `store.near_vector`
- `db_search.get_token_usage_stats` → `store.iterate`
- `db_search.search_functions_hybrid` → explicit Pro-only guard with helpful message

`get_cached_client` is gone from `db_search.py`, `return_caching_utils.py`, and `replayer.py`. The only remaining direct Weaviate-client users are the legitimate ones (the Pro adapter, schema init, status).

### Tests

`test_lite_mode.py` grows from 3 to 7 cases:

- Original three: log lands in LanceDB / `find_executions` filters / no-Weaviate sanity
- New: archiver export+clear, dataset register_as_golden, search_similar_execution, drift safety + happy-path

`test_return_caching.py` and `test_replay_source.py` adapt their fixtures from mocking `get_cached_client` to mocking `get_vector_store`; golden hits use a `StoreRecord` instead of a fake Weaviate object.

### Docs

CONTRIBUTING.md "Modes: Pro vs Lite" now lists every feature with a mode-by-mode tick, calls out the one Pro-only item (`search_functions_hybrid`), and notes the Lite filter strategy (Python-side after fetch — fine for ≲100k rows; switch to Pro for multi-million-row workloads).

## Test Results

```
148 passed, 8 skipped (benchmarks), 0 failed in 138s (-m "not live")
```

Up from 144 in the OTel PR (#115). No regressions.

## Try it

```bash
pip install -e ".[lite]"
export VECTORWAVE_MODE=lite

python - <<'PY'
from vectorwave import vectorize
from vectorwave.database.archiver import VectorWaveArchiver
from vectorwave.database.dataset import VectorWaveDatasetManager
from vectorwave.utils.replayer import VectorWaveReplayer

@vectorize(search_description="add", sequence_narrative="add", capture_return_value=True)
def add(a, b): return a + b

for i in range(5):
    add(i, i + 1)

# All of these now work without Docker / Weaviate:
VectorWaveArchiver().export_and_clear(function_name="add", output_file="out.jsonl", clear_after_export=False)
VectorWaveReplayer().replay("__main__.add", limit=3)
PY
```