### PR TITLE
ci(nightly): tolerate empty live-test set

### DIFF
--- a/.github/workflows/nightly_live.yml
+++ b/.github/workflows/nightly_live.yml
@@ -42,7 +42,19 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: pytest -m "live" --tb=short
+        # pytest exits with code 5 when nothing matches the `live` marker —
+        # that's an expected state until someone adds the first live test, not
+        # a failure. Swallow code 5; surface every other exit code.
+        run: |
+          set +e
+          pytest -m "live" --tb=short
+          code=$?
+          set -e
+          if [ $code -eq 5 ]; then
+            echo "::notice::No @pytest.mark.live tests collected — skipping."
+            exit 0
+          fi
+          exit $code
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Summary

The nightly Live API workflow has been failing because nothing in the suite is marked `@pytest.mark.live` yet. pytest exits with code 5 (\"no tests collected\") in that case and the job treated it as a real failure.

## Bug Fix

\`pytest -m \"live\"\` returns exit code 5 when no test matches the marker. The marker was added in PR #111 so we can later opt specific cassette-replayed tests into running against the real OpenAI/Anthropic backends on a schedule; no tests have actually adopted it yet.

Swallow exit code 5 inside the workflow step (emit a workflow notice instead) so the nightly stays green until the first live test lands. Every other non-zero code still propagates and fires the existing \`Notify on failure\` step.

## Changes

\`.github/workflows/nightly_live.yml\`: wrap the \`pytest -m \"live\"\` invocation with a shell guard:

\`\`\`bash
set +e
pytest -m \"live\" --tb=short
code=\$?
set -e
if [ \$code -eq 5 ]; then
  echo \"::notice::No @pytest.mark.live tests collected — skipping.\"
  exit 0
fi
exit \$code
\`\`\`

## Test Results

Workflow change only — no code touched. Re-runs the nightly schedule with the same \`workflow_dispatch\` trigger.