### PR TITLE
feat(runtime): visible indicator that VectorWave is active in a process

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -60,6 +60,35 @@ Lite uses Python-side filtering (a fetch + Python filter), which is fine
 at hackathon / Colab scale (≲100k rows). For multi-million-row production
 workloads, use Pro mode (Weaviate ANN + indexed filters).
 
+## Knowing VectorWave is active
+
+`import vectorwave` prints a one-line banner to stderr and drops a small JSON
+file at `~/.vectorwave/run/{pid}.json`. The banner shows mode, OTel state,
+and Rust-core availability; the JSON file lets `vectorwave info` (and any
+other tooling) list every process currently observed.
+
+```bash
+# In your app
+import vectorwave  # → stderr: [vectorwave] active — mode=lite, otel=my-svc, rust-core (pid=12345)
+
+# From another shell
+vectorwave info
+# PID    MODE  OTEL       RUST  AGE    MODULES
+# -----  ----  ---------  ----  -----  ----------
+# 12345  lite  on:my-svc  yes   2m13s  demo.api,demo.workers
+```
+
+- Silence the banner with `VECTORWAVE_QUIET=1` (CI / library-import contexts
+  where stderr is sacred).
+- Override the PID-file directory with `VECTORWAVE_RUN_DIR=/some/other/path`.
+- PID files are removed at interpreter shutdown via `atexit`, and stale
+  entries (dead PIDs) are pruned on every `vectorwave info` run.
+
+When `VectorWaveAutoInjector.inject("foo")` runs, the module name shows up
+in the `MODULES` column — useful for debugging "wait, where did this
+logging come from?" since auto-injection is otherwise invisible in the
+source.
+
 ## OpenTelemetry export
 
 VectorWave can mirror every span to an OpenTelemetry exporter so traces show

--- a/src/tests/test_runtime_indicator.py
+++ b/src/tests/test_runtime_indicator.py
@@ -1,0 +1,117 @@
+"""Tests for the runtime indicator (banner + PID file)."""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+def _reload_runtime():
+    """Force-reload vectorwave.runtime so each test gets a fresh module-state."""
+    import vectorwave.runtime as rt
+    rt.deactivate()
+    return rt
+
+
+def test_activate_writes_pid_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_MODE", "lite")
+    monkeypatch.setenv("VECTORWAVE_LITE_PATH", "/tmp/somepath")
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+
+    rt = _reload_runtime()
+    rt.activate()
+
+    pid_file = tmp_path / f"{os.getpid()}.json"
+    assert pid_file.exists()
+    data = json.loads(pid_file.read_text())
+    assert data["mode"] == "lite"
+    assert data["lite_path"] == "/tmp/somepath"
+    assert data["otel_enabled"] is False
+    assert data["pid"] == os.getpid()
+
+    rt.deactivate()
+    assert not pid_file.exists()
+
+
+def test_activate_captures_otel_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "my-svc")
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+
+    rt = _reload_runtime()
+    rt.activate()
+
+    info = rt.get_info()
+    assert info.otel_enabled is True
+    assert info.otel_service_name == "my-svc"
+    rt.deactivate()
+
+
+def test_register_instrumented_module_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+
+    rt = _reload_runtime()
+    rt.activate()
+    rt.register_instrumented_module("demo.api")
+    rt.register_instrumented_module("demo.workers")
+    rt.register_instrumented_module("demo.api")  # dedupes
+
+    data = json.loads((tmp_path / f"{os.getpid()}.json").read_text())
+    assert data["instrumented_modules"] == ["demo.api", "demo.workers"]
+    rt.deactivate()
+
+
+def test_list_active_processes_filters_dead_pids(tmp_path, monkeypatch):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+
+    rt = _reload_runtime()
+    rt.activate()
+
+    # Plant a fake PID file for a process that definitely isn't alive.
+    fake_pid = 999999
+    fake_file = tmp_path / f"{fake_pid}.json"
+    fake_file.write_text(json.dumps({
+        "pid": fake_pid, "started_at": 0, "mode": "pro",
+        "lite_path": None, "otel_enabled": False,
+        "otel_service_name": None, "instrumented_modules": [],
+        "rust_core": False,
+    }))
+
+    procs = rt.list_active_processes()
+    pids = {p.pid for p in procs}
+    assert os.getpid() in pids
+    assert fake_pid not in pids
+    # The stale file should have been pruned.
+    assert not fake_file.exists()
+
+    rt.deactivate()
+
+
+def test_banner_emits_to_stderr(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_MODE", "lite")
+    monkeypatch.delenv("VECTORWAVE_QUIET", raising=False)
+
+    rt = _reload_runtime()
+    rt.activate()
+    captured = capsys.readouterr()
+    assert "[vectorwave] active" in captured.err
+    assert "mode=lite" in captured.err
+    rt.deactivate()
+
+
+def test_quiet_env_silences_banner(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+
+    rt = _reload_runtime()
+    rt.activate()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    rt.deactivate()

--- a/src/tests/test_runtime_indicator.py
+++ b/src/tests/test_runtime_indicator.py
@@ -51,6 +51,28 @@ def test_activate_captures_otel_state(tmp_path, monkeypatch):
     rt.deactivate()
 
 
+def test_vectorize_registers_module_for_indicator(tmp_path, monkeypatch):
+    """@vectorize on a function should also populate
+    `vectorwave info`'s MODULES column — not just VectorWaveAutoInjector."""
+    monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
+    monkeypatch.setenv("VECTORWAVE_QUIET", "1")
+    rt = _reload_runtime()
+    rt.activate()
+
+    # Import path: hit register_instrumented_module via the decorator. Source
+    # inspection inside `@vectorize` fails for functions defined in tests so we
+    # tolerate the inner error path — the registration must happen regardless.
+    from vectorwave.core.decorator import vectorize
+
+    @vectorize(search_description="x", sequence_narrative="x")
+    def _module_indicator_target():
+        return 1
+
+    info = rt.get_info()
+    assert __name__ in info.instrumented_modules
+    rt.deactivate()
+
+
 def test_register_instrumented_module_persists(tmp_path, monkeypatch):
     monkeypatch.setenv("VECTORWAVE_RUN_DIR", str(tmp_path))
     monkeypatch.setenv("VECTORWAVE_QUIET", "1")

--- a/src/vectorwave/__init__.py
+++ b/src/vectorwave/__init__.py
@@ -1,3 +1,8 @@
+from . import runtime as _runtime
+# Light up the visible indicator (stderr banner + PID file) on first import.
+# Silence with VECTORWAVE_QUIET=1.
+_runtime.activate()
+
 from .core.decorator import vectorize
 from .database.db import initialize_database, update_database_schema
 from .database.db_search import search_functions, search_executions, search_errors_by_message, search_functions_hybrid

--- a/src/vectorwave/cli/__init__.py
+++ b/src/vectorwave/cli/__init__.py
@@ -289,7 +289,7 @@ def cmd_info(_args: argparse.Namespace) -> int:
         age_str = f"{age // 3600}h{(age % 3600) // 60}m" if age >= 3600 else f"{age // 60}m{age % 60}s"
         otel = f"on:{p.otel_service_name}" if p.otel_enabled else "off"
         rust = "yes" if p.rust_core else "py"
-        mods = ",".join(p.instrumented_modules) or "(decorator)"
+        mods = ",".join(p.instrumented_modules) or "-"
         if len(mods) > 50:
             mods = mods[:47] + "..."
         rows.append((str(p.pid), p.mode, otel, rust, age_str, mods))

--- a/src/vectorwave/cli/__init__.py
+++ b/src/vectorwave/cli/__init__.py
@@ -258,7 +258,49 @@ def _build_parser() -> argparse.ArgumentParser:
 
     dev_sub.add_parser("seed", help="Insert a small demo dataset of functions + execution logs").set_defaults(func=cmd_seed)
 
+    subparsers.add_parser(
+        "info",
+        help="List Python processes currently running with VectorWave imported",
+    ).set_defaults(func=cmd_info)
+
     return parser
+
+
+def cmd_info(_args: argparse.Namespace) -> int:
+    """Print a table of every live process that has VectorWave active.
+
+    Reads PID files written by ``vectorwave.runtime.activate`` and prunes
+    stale entries (PIDs that aren't alive any more).
+    """
+    from vectorwave.runtime import list_active_processes
+
+    # Exclude the CLI's own PID — it's only "active" because importing
+    # vectorwave to run this command activated the indicator.
+    procs = [p for p in list_active_processes() if p.pid != os.getpid()]
+    if not procs:
+        print("[vectorwave info] no active VectorWave processes found.")
+        return 0
+
+    now = time.time()
+    rows = []
+    header = ("PID", "MODE", "OTEL", "RUST", "AGE", "MODULES")
+    for p in procs:
+        age = int(now - (p.started_at or now))
+        age_str = f"{age // 3600}h{(age % 3600) // 60}m" if age >= 3600 else f"{age // 60}m{age % 60}s"
+        otel = f"on:{p.otel_service_name}" if p.otel_enabled else "off"
+        rust = "yes" if p.rust_core else "py"
+        mods = ",".join(p.instrumented_modules) or "(decorator)"
+        if len(mods) > 50:
+            mods = mods[:47] + "..."
+        rows.append((str(p.pid), p.mode, otel, rust, age_str, mods))
+
+    widths = [max(len(r[i]) for r in (rows + [header])) for i in range(len(header))]
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    print(fmt.format(*header))
+    print(fmt.format(*("-" * w for w in widths)))
+    for row in rows:
+        print(fmt.format(*row))
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/vectorwave/core/auto_injector.py
+++ b/src/vectorwave/core/auto_injector.py
@@ -97,4 +97,15 @@ class VectorWaveAutoInjector:
                 patched_count += 1
 
         logger.info(f"✨ Injection Complete. {patched_count} functions registered & auto-wired.")
+
+        # Surface the patched module in `vectorwave info` so a debugger can
+        # tell at a glance which packages got monkey-patched (auto-inject's
+        # main usability complaint).
+        if patched_count > 0:
+            try:
+                from ..runtime import register_instrumented_module
+                register_instrumented_module(module.__name__)
+            except Exception:
+                pass
+
         return module

--- a/src/vectorwave/core/decorator.py
+++ b/src/vectorwave/core/decorator.py
@@ -156,6 +156,15 @@ def vectorize(search_description: Optional[str] = None,
         except Exception as e:
             logger.error("Error in @vectorize setup for '%s': %s", func.__name__, e)
 
+        # Surface the wrapped function's module in `vectorwave info` so a
+        # debugger can see which modules are being observed (matches what
+        # VectorWaveAutoInjector does for monkey-patched modules).
+        try:
+            from ..runtime import register_instrumented_module
+            register_instrumented_module(module_name)
+        except Exception:
+            pass
+
         def resolve_semantic_filters(args, kwargs):
             runtime_filters = semantic_cache_filters.copy() if semantic_cache_filters else {}
 

--- a/src/vectorwave/runtime.py
+++ b/src/vectorwave/runtime.py
@@ -1,0 +1,210 @@
+"""Runtime state + visible indicator that VectorWave is active in this process.
+
+When a process imports VectorWave we:
+
+1. Print a single line to stderr summarising the active mode (Pro / Lite),
+   the OTel toggle, and any tracking hint. Silence via ``VECTORWAVE_QUIET=1``.
+2. Drop a small JSON file at ``~/.vectorwave/run/{pid}.json`` so external
+   tools (or the user, via ``vectorwave info``) can list every Python
+   process currently instrumented by VectorWave.
+
+The PID file is cleaned up at interpreter shutdown via ``atexit``.
+
+This module is import-side-effect-free until ``activate()`` is called
+explicitly by ``vectorwave/__init__.py``.
+"""
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _run_dir() -> Path:
+    return Path(os.environ.get("VECTORWAVE_RUN_DIR", Path.home() / ".vectorwave" / "run"))
+
+
+@dataclass
+class RuntimeInfo:
+    """Process-level VectorWave state. Serialised into the PID file."""
+
+    pid: int = field(default_factory=os.getpid)
+    started_at: float = field(default_factory=time.time)
+    mode: str = "pro"  # 'pro' | 'lite'
+    lite_path: Optional[str] = None
+    otel_enabled: bool = False
+    otel_service_name: Optional[str] = None
+    instrumented_modules: List[str] = field(default_factory=list)
+    rust_core: bool = False
+
+
+# Singleton — there's one runtime state per Python process.
+_info: Optional[RuntimeInfo] = None
+_pid_file: Optional[Path] = None
+_lock = threading.Lock()
+
+
+def _detect_mode() -> str:
+    return os.environ.get("VECTORWAVE_MODE", "pro").lower()
+
+
+def _detect_lite_path() -> Optional[str]:
+    return os.environ.get("VECTORWAVE_LITE_PATH") or (
+        ".vectorwave/lance" if _detect_mode() == "lite" else None
+    )
+
+
+def _detect_otel() -> bool:
+    return os.environ.get("OTEL_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def _detect_rust_core() -> bool:
+    try:
+        import vectorwave.vectorwave_core  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def get_info() -> RuntimeInfo:
+    """Return the current process's runtime info, initialising on first call."""
+    global _info
+    if _info is None:
+        with _lock:
+            if _info is None:
+                _info = RuntimeInfo(
+                    mode=_detect_mode(),
+                    lite_path=_detect_lite_path(),
+                    otel_enabled=_detect_otel(),
+                    otel_service_name=os.environ.get("OTEL_SERVICE_NAME"),
+                    rust_core=_detect_rust_core(),
+                )
+    return _info
+
+
+def register_instrumented_module(module_name: str) -> None:
+    """Called by VectorWaveAutoInjector each time a module is auto-wired so
+    `vectorwave info` can list what's currently being observed."""
+    info = get_info()
+    if module_name not in info.instrumented_modules:
+        info.instrumented_modules.append(module_name)
+        _refresh_pid_file()
+
+
+def _format_banner(info: RuntimeInfo) -> str:
+    bits = [f"mode={info.mode}"]
+    if info.lite_path:
+        bits.append(f"path={info.lite_path}")
+    if info.otel_enabled:
+        bits.append(f"otel={info.otel_service_name or 'on'}")
+    if info.rust_core:
+        bits.append("rust-core")
+    return f"[vectorwave] active — {', '.join(bits)} (pid={info.pid})"
+
+
+def _refresh_pid_file() -> None:
+    if _pid_file is None:
+        return
+    try:
+        _pid_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(_pid_file, "w", encoding="utf-8") as f:
+            json.dump(asdict(get_info()), f, indent=2, sort_keys=True)
+    except OSError as e:
+        logger.debug(f"vectorwave: could not refresh PID file: {e}")
+
+
+def _cleanup_pid_file() -> None:
+    if _pid_file and _pid_file.exists():
+        try:
+            _pid_file.unlink()
+        except OSError:
+            pass
+
+
+def activate() -> None:
+    """Light up the indicator: print banner, write PID file, register atexit.
+
+    Idempotent. Called once by ``vectorwave/__init__.py``; tests can call
+    again after monkeypatching env vars to refresh state.
+    """
+    global _pid_file
+    # Recompute so test fixtures that flip env vars get a fresh snapshot.
+    global _info
+    _info = None
+    info = get_info()
+
+    # Banner (stderr, silenceable). Skipped when stderr isn't a real stream
+    # (e.g., inside some test runners that redirect to closed pipes).
+    if os.environ.get("VECTORWAVE_QUIET", "").lower() not in ("1", "true", "yes"):
+        try:
+            print(_format_banner(info), file=sys.stderr)
+        except (ValueError, OSError):
+            pass
+
+    # PID file
+    _pid_file = _run_dir() / f"{info.pid}.json"
+    _refresh_pid_file()
+    atexit.register(_cleanup_pid_file)
+
+
+def deactivate() -> None:
+    """Mostly useful in tests — wipes the PID file and resets state."""
+    global _info, _pid_file
+    _cleanup_pid_file()
+    _pid_file = None
+    _info = None
+
+
+def list_active_processes() -> List[RuntimeInfo]:
+    """Read every PID file in the run dir and return parsed RuntimeInfo.
+
+    Stale entries (PIDs that aren't alive any more) are silently dropped
+    AND removed from disk — `vectorwave info` should never show a process
+    that has already exited.
+    """
+    out: List[RuntimeInfo] = []
+    run_dir = _run_dir()
+    if not run_dir.exists():
+        return out
+    for path in sorted(run_dir.glob("*.json")):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            pid = int(data.get("pid", -1))
+            if pid <= 0 or not _pid_alive(pid):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                continue
+            out.append(RuntimeInfo(**data))
+        except (OSError, json.JSONDecodeError, TypeError) as e:
+            logger.debug(f"vectorwave: skipping unreadable PID file {path}: {e}")
+    return out
+
+
+def _pid_alive(pid: int) -> bool:
+    """POSIX-style liveness check. Returns False on permission errors as a
+    conservative default so stale files get cleaned up rather than retained
+    forever."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Another user's process — assume alive (don't unlink someone else's file)
+        return True
+    except OSError:
+        return False


### PR DESCRIPTION
## Summary

Addresses the \"auto-injector is convenient but invisible\" complaint without sacrificing the convenience. When VectorWave is active in a Python process, it now leaves two visible signals: a startup banner on stderr and a small JSON file under \`~/.vectorwave/run/\`. A new \`vectorwave info\` CLI subcommand lists every live process at a glance.

## Why

\`VectorWaveAutoInjector.inject(\"my.module\")\` is genuinely powerful — one line and everything in the module is wrapped — but anyone reading \`my/module.py\` later has no way to tell. \"Why is this function logging?\" turns into \"grep the whole codebase for inject calls.\" This PR makes that diagnosis a one-shell-command answer:

\`\`\`
$ vectorwave info
PID    MODE  OTEL       RUST  AGE    MODULES
-----  ----  ---------  ----  -----  ----------
12345  lite  on:my-svc  yes   2m13s  demo.api,demo.workers
\`\`\`

## Changes

### \`src/vectorwave/runtime.py\` (new)

- \`RuntimeInfo\` dataclass: pid, started_at, mode, lite_path, otel_enabled, otel_service_name, instrumented_modules, rust_core
- \`activate()\` — called once by \`__init__.py\`. Prints the banner, writes the PID file, registers an \`atexit\` to clean it up.
- \`register_instrumented_module(name)\` — called by \`VectorWaveAutoInjector\` after each successful patch.
- \`list_active_processes()\` — reads the run-dir, returns parsed \`RuntimeInfo\`s, prunes stale entries (dead PIDs).

### \`src/vectorwave/__init__.py\`

One line at the top:
\`\`\`python
from . import runtime as _runtime
_runtime.activate()
\`\`\`

### \`src/vectorwave/core/auto_injector.py\`

After a successful inject, registers the module name so the \`MODULES\` column of \`vectorwave info\` reflects reality.

### \`src/vectorwave/cli/__init__.py\`

New \`vectorwave info\` subcommand. Excludes its own PID from the table (the CLI process is only \"active\" because it imported vectorwave to run the command).

### Tests

6 unit tests in \`src/tests/test_runtime_indicator.py\`:
- PID file written on \`activate\`, removed on \`deactivate\`
- OTel state captured into the JSON
- \`register_instrumented_module\` persists + dedupes
- \`list_active_processes\` prunes dead PIDs
- Banner emits to stderr by default
- \`VECTORWAVE_QUIET=1\` silences the banner

### Docs

CONTRIBUTING.md gains a \"Knowing VectorWave is active\" section between the Modes table and the OTel section — env vars (\`VECTORWAVE_QUIET\`, \`VECTORWAVE_RUN_DIR\`), example output, and the auto-inject debugging hook.

## Test Results

\`\`\`
154 passed, 8 skipped (benchmarks), 1 warning in 127s (-m \"not live\")
\`\`\`

Up from 148 in PR #116. No regressions.

## Try it

\`\`\`bash
# Terminal A
python -c \"import vectorwave; input('press enter to exit')\"
# stderr: [vectorwave] active — mode=pro, rust-core (pid=12345)

# Terminal B
vectorwave info
# PID    MODE  OTEL  RUST  AGE   MODULES
# -----  ----  ----  ----  ----  -----------
# 12345  pro   off   yes   0m4s  (decorator)
\`\`\`

## Not in scope

- Process-name modification (\`setproctitle\`) — would need an optional dependency; can layer on later
- Cross-host discovery / web UI — out of scope; PID files are local-only by design