### PR TITLE
feat(check): pytest plugin + calibration CLI for semantic regression testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "requests",
     "openai",
     "PyGithub",
-    "schedule"
+    "schedule",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
@@ -60,6 +61,9 @@ otel = [
 
 [project.scripts]
 vectorwave = "vectorwave.cli:main"
+
+[project.entry-points.pytest11]
+vectorwave_check = "vectorwave.check.plugin"
 
 [project.urls]
 Repository = "https://github.com/cozymori/vectorwave"

--- a/src/tests/check/test_calibrate.py
+++ b/src/tests/check/test_calibrate.py
@@ -1,0 +1,153 @@
+"""Unit tests for the calibration math + summary logic.
+
+These tests cover the pure functions only (cosine, percentile, summarize,
+formatters). End-to-end calibration against a real vector store + golden
+data lives in nightly_live.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vectorwave.check.calibrate import (
+    CalibrationResult,
+    PERCENTILES,
+    _cosine,
+    _pairwise_similarities,
+    _percentile,
+    _summarize,
+    format_pyproject_snippet,
+    format_report,
+)
+
+
+def test_cosine_identical_vectors_returns_one():
+    v = [1.0, 2.0, 3.0]
+    assert _cosine(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal_vectors_returns_zero():
+    assert _cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_cosine_opposite_vectors_returns_negative_one():
+    assert _cosine([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+
+def test_cosine_zero_vector_returns_zero():
+    assert _cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+def test_percentile_empty_returns_zero():
+    assert _percentile([], 50) == 0.0
+
+
+def test_percentile_single_value_returns_that_value():
+    assert _percentile([0.7], 5) == 0.7
+    assert _percentile([0.7], 95) == 0.7
+
+
+def test_percentile_interpolates_between_ranks():
+    # 0, 1, 2, 3, 4 → p50 should be 2.0 (middle)
+    values = [0.0, 1.0, 2.0, 3.0, 4.0]
+    assert _percentile(values, 50) == pytest.approx(2.0)
+    # p25 should land at index 1.0 → exactly 1.0
+    assert _percentile(values, 25) == pytest.approx(1.0)
+    # p75 should land at index 3.0 → exactly 3.0
+    assert _percentile(values, 75) == pytest.approx(3.0)
+
+
+def test_pairwise_similarities_count():
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+    pairs = _pairwise_similarities(embeddings)
+    assert len(pairs) == 3  # N choose 2 for N=3
+
+
+def test_pairwise_similarities_empty_for_single_vector():
+    assert _pairwise_similarities([[1.0, 2.0]]) == []
+
+
+def test_summarize_recommends_p5_threshold_for_normal_function():
+    sims = [0.7, 0.75, 0.8, 0.85, 0.9, 0.92, 0.95, 0.97, 0.98, 0.99]
+    result = _summarize("myapp.fn", "diversity", sample_count=10, similarities=sims, vectorizer_name="HF")
+    assert result.recommended_strategy == "similarity"
+    assert result.recommended_threshold is not None
+    assert result.recommended_threshold == pytest.approx(result.percentiles[5])
+    assert "exact" not in " ".join(result.notes).lower()
+
+
+def test_summarize_flags_deterministic_function_with_exact_recommendation():
+    sims = [1.0] * 20
+    result = _summarize("myapp.detfn", "diversity", sample_count=20, similarities=sims, vectorizer_name="HF")
+    assert result.recommended_strategy == "exact"
+    assert result.recommended_threshold is None
+    assert any("deterministic" in n.lower() for n in result.notes)
+
+
+def test_summarize_flags_highly_noisy_function_with_llm_recommendation():
+    sims = [0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55]
+    result = _summarize("myapp.chaos", "diversity", sample_count=7, similarities=sims, vectorizer_name="HF")
+    assert result.recommended_strategy == "llm"
+    assert any("llm" in n.lower() for n in result.notes)
+
+
+def test_summarize_empty_similarities_emits_note():
+    result = _summarize("myapp.empty", "diversity", sample_count=1, similarities=[], vectorizer_name="HF")
+    assert result.recommended_threshold is None
+    assert any("no similarity pairs" in n.lower() for n in result.notes)
+
+
+def test_summarize_returns_all_requested_percentiles():
+    sims = [0.5, 0.6, 0.7, 0.8, 0.9]
+    result = _summarize("myapp.fn", "diversity", sample_count=5, similarities=sims, vectorizer_name="HF")
+    for p in PERCENTILES:
+        assert p in result.percentiles
+
+
+def test_format_pyproject_snippet_similarity_strategy():
+    result = CalibrationResult(
+        function="myapp.summarize",
+        mode="diversity",
+        sample_count=10,
+        pair_count=45,
+        percentiles={5: 0.812, 50: 0.91},
+        recommended_threshold=0.812,
+        recommended_strategy="similarity",
+    )
+    snippet = format_pyproject_snippet(result)
+    assert '[tool.vectorwave.check."myapp.summarize"]' in snippet
+    assert 'strategy = "similarity"' in snippet
+    assert "threshold = 0.812" in snippet
+
+
+def test_format_pyproject_snippet_exact_strategy_omits_threshold():
+    result = CalibrationResult(
+        function="myapp.id",
+        mode="diversity",
+        sample_count=10,
+        pair_count=45,
+        recommended_threshold=None,
+        recommended_strategy="exact",
+    )
+    snippet = format_pyproject_snippet(result)
+    assert 'strategy = "exact"' in snippet
+    assert "threshold" not in snippet
+
+
+def test_format_report_contains_percentiles_and_recommendation():
+    result = CalibrationResult(
+        function="myapp.fn",
+        mode="rerun",
+        sample_count=3,
+        pair_count=135,
+        percentiles={p: 0.5 + p / 200 for p in PERCENTILES},
+        recommended_threshold=0.525,
+        recommended_strategy="similarity",
+        vectorizer_name="HuggingFaceVectorizer",
+    )
+    text = format_report(result)
+    assert "myapp.fn" in text
+    assert "mode=rerun" in text
+    assert "HuggingFaceVectorizer" in text
+    assert "p5" in text and "p95" in text
+    assert "Recommended" in text
+    assert "pyproject.toml" in text

--- a/src/tests/check/test_plugin_smoke.py
+++ b/src/tests/check/test_plugin_smoke.py
@@ -1,0 +1,236 @@
+"""Smoke tests for the vectorwave-check pytest plugin.
+
+These verify the plugin's structural correctness without hitting Weaviate.
+End-to-end golden-data tests against a real store live in nightly_live.
+"""
+from __future__ import annotations
+
+pytest_plugins = ["pytester"]
+
+
+def test_marker_is_registered_under_strict(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(target="fake.target")
+        def test_dummy():
+            pass
+        """
+    )
+    pytester.makeconftest(
+        """
+        import pytest
+        from vectorwave.check import plugin
+        from vectorwave.check.plugin import ReplayResult
+
+        @pytest.fixture(autouse=True)
+        def _fake_replay(monkeypatch):
+            monkeypatch.setattr(
+                plugin,
+                "_run_replay",
+                lambda **_: ReplayResult(function="fake.target", total=1, passed=1, failed=0),
+            )
+        """
+    )
+    result = pytester.runpytest("--strict-markers")
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_requires_target(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(strategy="exact")
+        def test_no_target():
+            pass
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(["*requires a `target`*"])
+
+
+def test_fixture_is_injected(pytester):
+    pytester.makepyfile(
+        """
+        def test_fixture_callable(vw_replay):
+            assert callable(vw_replay)
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_passes_when_replay_clean(pytester):
+    pytester.makeconftest(
+        """
+        import pytest
+        from vectorwave.check import plugin
+        from vectorwave.check.plugin import ReplayResult
+
+        @pytest.fixture(autouse=True)
+        def _fake_replay(monkeypatch):
+            monkeypatch.setattr(
+                plugin,
+                "_run_replay",
+                lambda **_: ReplayResult(function="fake.target", total=5, passed=5, failed=0),
+            )
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(target="fake.target", strategy="similarity", threshold=0.85)
+        def test_replay():
+            pass
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_fails_with_report_when_replay_dirty(pytester):
+    pytester.makeconftest(
+        """
+        import pytest
+        from vectorwave.check import plugin
+        from vectorwave.check.plugin import ReplayResult
+
+        @pytest.fixture(autouse=True)
+        def _fake_replay(monkeypatch):
+            monkeypatch.setattr(
+                plugin,
+                "_run_replay",
+                lambda **_: ReplayResult(
+                    function="fake.target",
+                    total=3,
+                    passed=1,
+                    failed=2,
+                    failures=[
+                        {"uuid": "abc", "reason": "Low Similarity (0.70 < 0.85)",
+                         "expected": "hello world", "actual": "hi"},
+                        {"uuid": "def", "reason": "Exact match failed",
+                         "expected": 42, "actual": 41},
+                    ],
+                ),
+            )
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(target="fake.target", strategy="similarity", threshold=0.85)
+        def test_replay():
+            pass
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*2/3 regression check*failed*",
+            "*UUID abc*Low Similarity*",
+            "*UUID def*Exact match failed*",
+        ]
+    )
+
+
+def test_invalid_strategy_raises_clear_error(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(target="fake.target", strategy="nonsense")
+        def test_bogus():
+            pass
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1, errors=0)
+    result.stdout.fnmatch_lines(["*Invalid strategy*nonsense*"])
+
+
+def test_fixture_returns_replay_result(pytester):
+    pytester.makeconftest(
+        """
+        import pytest
+        from vectorwave.check import plugin
+        from vectorwave.check.plugin import ReplayResult
+
+        @pytest.fixture(autouse=True)
+        def _fake_replay(monkeypatch):
+            monkeypatch.setattr(
+                plugin,
+                "_run_replay",
+                lambda **_: ReplayResult(function="fake.target", total=2, passed=2, failed=0),
+            )
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_fixture(vw_replay):
+            result = vw_replay("fake.target", strategy="exact")
+            assert result.passed_all
+            assert result.total == 2
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_pyproject_config_layers_under_marker(pytester):
+    pytester.makepyfile(
+        pyproject="",  # placeholder, real one below
+    )
+    pytester.makefile(
+        ".toml",
+        pyproject=(
+            "[tool.vectorwave.check]\n"
+            'strategy = "exact"\n'
+            "threshold = 0.7\n"
+            "\n"
+            "[tool.vectorwave.check.\"fake.target\"]\n"
+            'strategy = "similarity"\n'
+            "threshold = 0.9\n"
+        ),
+    )
+    pytester.makeconftest(
+        """
+        import pytest
+        from vectorwave.check import plugin
+        from vectorwave.check.plugin import ReplayResult
+
+        captured = {}
+
+        @pytest.fixture(autouse=True)
+        def _spy(monkeypatch):
+            def fake(**kw):
+                captured.update(kw)
+                return ReplayResult(function=kw["target"], total=1, passed=1, failed=0)
+            monkeypatch.setattr(plugin, "_run_replay", fake)
+
+        @pytest.fixture
+        def captured_kw():
+            return captured
+        """
+    )
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.vectorwave(target="fake.target")
+        def test_uses_per_function_table():
+            pass
+
+        def test_assertions(captured_kw):
+            # per-function table beats global defaults
+            assert captured_kw["strategy"] == "similarity"
+            assert captured_kw["threshold"] == 0.9
+        """
+    )
+    result = pytester.runpytest("-p", "no:cacheprovider")
+    result.assert_outcomes(passed=2)

--- a/src/vectorwave/check/__init__.py
+++ b/src/vectorwave/check/__init__.py
@@ -1,0 +1,17 @@
+"""VectorWave Check: pytest plugin + CLI for semantic regression testing.
+
+Quick usage (declarative marker):
+
+    @pytest.mark.vectorwave(target="myapp.summarize", strategy="similarity", threshold=0.85)
+    def test_summarize_regression():
+        pass
+
+Quick usage (imperative fixture):
+
+    def test_summarize_regression(vw_replay):
+        result = vw_replay("myapp.summarize", strategy="similarity", threshold=0.85)
+        assert result.passed_all, result.report()
+"""
+from .plugin import ReplayResult
+
+__all__ = ["ReplayResult"]

--- a/src/vectorwave/check/calibrate.py
+++ b/src/vectorwave/check/calibrate.py
@@ -1,0 +1,358 @@
+"""Threshold calibration for the vectorwave-check pytest plugin.
+
+Two measurement modes:
+
+* **diversity** (default) — pull existing golden outputs for the target,
+  compute pairwise cosine similarity. Reports how diverse the function's
+  typical outputs are. No function calls, no side effects.
+* **rerun** — sample a few golden inputs, re-execute the function N times
+  per input, compute pairwise similarity within each input group. Reports
+  the function's intrinsic noise floor. Hits the function (and any APIs it
+  calls); skip for functions with side effects.
+
+Both modes emit the same shape so the downstream CLI / pyproject snippet
+generator can stay one path.
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import importlib
+import inspect
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+PERCENTILES = (5, 10, 25, 50, 75, 95)
+
+
+@dataclass
+class CalibrationResult:
+    function: str
+    mode: str
+    sample_count: int  # how many goldens (diversity) / inputs sampled (rerun)
+    pair_count: int    # how many similarity pairs computed
+    percentiles: Dict[int, float] = field(default_factory=dict)
+    recommended_threshold: Optional[float] = None
+    recommended_strategy: str = "similarity"
+    notes: List[str] = field(default_factory=list)
+    vectorizer_name: Optional[str] = None
+
+
+def _cosine(v1: Sequence[float], v2: Sequence[float]) -> float:
+    dot = 0.0
+    n1 = 0.0
+    n2 = 0.0
+    for a, b in zip(v1, v2):
+        dot += a * b
+        n1 += a * a
+        n2 += b * b
+    if n1 == 0 or n2 == 0:
+        return 0.0
+    return dot / (math.sqrt(n1) * math.sqrt(n2))
+
+
+def _percentile(sorted_values: List[float], p: int) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    # linear interpolation between closest ranks
+    k = (len(sorted_values) - 1) * p / 100.0
+    lo = int(math.floor(k))
+    hi = int(math.ceil(k))
+    if lo == hi:
+        return sorted_values[lo]
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * (k - lo)
+
+
+def _pairwise_similarities(embeddings: List[Sequence[float]]) -> List[float]:
+    out: List[float] = []
+    for i in range(len(embeddings)):
+        for j in range(i + 1, len(embeddings)):
+            out.append(_cosine(embeddings[i], embeddings[j]))
+    return out
+
+
+def _embed_all(vectorizer, texts: List[str]) -> List[Sequence[float]]:
+    if hasattr(vectorizer, "embed_batch"):
+        try:
+            return vectorizer.embed_batch(texts)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("embed_batch failed (%s); falling back to per-text embed", e)
+    return [vectorizer.embed(t) for t in texts]
+
+
+def _summarize(
+    function: str,
+    mode: str,
+    sample_count: int,
+    similarities: List[float],
+    vectorizer_name: Optional[str],
+) -> CalibrationResult:
+    sims_sorted = sorted(similarities)
+    percentiles = {p: _percentile(sims_sorted, p) for p in PERCENTILES}
+
+    notes: List[str] = []
+    rec_threshold = percentiles.get(5)
+    rec_strategy = "similarity"
+
+    if not sims_sorted:
+        notes.append("No similarity pairs were computed — recommendation not available.")
+        rec_threshold = None
+    else:
+        p5 = percentiles[5]
+        p95 = percentiles[95]
+        if p5 > 0.99 and p95 > 0.99:
+            rec_strategy = "exact"
+            rec_threshold = None
+            notes.append(
+                "Function appears deterministic (p5 and p95 both >0.99). "
+                "Use `strategy=\"exact\"` instead of similarity."
+            )
+        elif p5 < 0.6:
+            rec_strategy = "llm"
+            notes.append(
+                f"Function is highly variable (p5={p5:.3f} < 0.6). "
+                "Similarity threshold will be noisy; consider `strategy=\"llm\"` "
+                "(LLM-as-a-judge) for more robust regression detection."
+            )
+
+    return CalibrationResult(
+        function=function,
+        mode=mode,
+        sample_count=sample_count,
+        pair_count=len(similarities),
+        percentiles=percentiles,
+        recommended_threshold=rec_threshold,
+        recommended_strategy=rec_strategy,
+        notes=notes,
+        vectorizer_name=vectorizer_name,
+    )
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        import json
+        return json.dumps(value, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _run_coroutine_safely(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coro).result()
+
+
+def _vectorizer_name(vectorizer) -> Optional[str]:
+    if vectorizer is None:
+        return None
+    return type(vectorizer).__name__
+
+
+# ---------------------------------------------------------------------------
+# Mode 1: diversity (cheap, default)
+# ---------------------------------------------------------------------------
+
+def _calibrate_diversity(function_full_name: str, samples: int) -> CalibrationResult:
+    from ..models.db_config import get_weaviate_settings
+    from ..store import get_vector_store
+    from ..utils.serialization import deserialize_return_value
+    from ..vectorizer.factory import get_vectorizer
+
+    func_short_name = function_full_name.rsplit(".", 1)[-1]
+    settings = get_weaviate_settings()
+    store = get_vector_store()
+    vectorizer = get_vectorizer()
+    if vectorizer is None:
+        raise RuntimeError(
+            "Calibration requires a local vectorizer (VECTORIZER=huggingface or openai_client). "
+            "Server-side vectorization (weaviate_module) cannot embed offline."
+        )
+
+    records = store.query(
+        collection=settings.GOLDEN_COLLECTION_NAME,
+        filters={"function_name": func_short_name},
+        limit=samples,
+    )
+
+    outputs: List[str] = []
+    for rec in records:
+        raw = rec.properties.get("return_value")
+        deserialized = deserialize_return_value(raw)
+        outputs.append(_stringify(deserialized))
+
+    if len(outputs) < 2:
+        raise RuntimeError(
+            f"Need at least 2 golden samples for '{function_full_name}', found {len(outputs)}. "
+            "Run the function a few times in production / replay-capture mode first, "
+            "or mark known-good executions as Golden."
+        )
+
+    embeddings = _embed_all(vectorizer, outputs)
+    similarities = _pairwise_similarities(embeddings)
+
+    return _summarize(
+        function=function_full_name,
+        mode="diversity",
+        sample_count=len(outputs),
+        similarities=similarities,
+        vectorizer_name=_vectorizer_name(vectorizer),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mode 2: rerun (honest noise floor, opt-in)
+# ---------------------------------------------------------------------------
+
+def _calibrate_rerun(
+    function_full_name: str,
+    samples: int,
+    runs: int,
+) -> CalibrationResult:
+    from ..models.db_config import get_weaviate_settings
+    from ..utils.replayer import VectorWaveReplayer
+    from ..vectorizer.factory import get_vectorizer
+
+    module_name, func_short_name = function_full_name.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    target_func = getattr(module, func_short_name)
+    is_async = inspect.iscoroutinefunction(target_func)
+
+    get_weaviate_settings()  # surface config errors early
+    vectorizer = get_vectorizer()
+    if vectorizer is None:
+        raise RuntimeError(
+            "Calibration requires a local vectorizer (VECTORIZER=huggingface or openai_client)."
+        )
+
+    helper = VectorWaveReplayer()
+    candidates = helper._fetch_test_candidates(func_short_name, limit=samples)
+    if not candidates:
+        raise RuntimeError(
+            f"No golden samples or execution logs found for '{function_full_name}'. "
+            "Rerun calibration needs at least one captured input."
+        )
+
+    all_similarities: List[float] = []
+    sampled = candidates[:samples]
+    for cand in sampled:
+        raw_inputs = cand["inputs"]
+        inputs = helper._extract_inputs(raw_inputs, target_func)
+        outputs: List[str] = []
+        for _ in range(runs):
+            try:
+                if is_async:
+                    out = _run_coroutine_safely(target_func(**inputs))
+                else:
+                    out = target_func(**inputs)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Calibration run raised %s; skipping this run", e)
+                continue
+            outputs.append(_stringify(out))
+        if len(outputs) >= 2:
+            embeddings = _embed_all(vectorizer, outputs)
+            all_similarities.extend(_pairwise_similarities(embeddings))
+
+    if not all_similarities:
+        raise RuntimeError(
+            "Rerun calibration produced no usable comparisons "
+            "(function raised every time, or only one successful run per input). "
+            "Inspect the function's behavior manually."
+        )
+
+    return _summarize(
+        function=function_full_name,
+        mode="rerun",
+        sample_count=len(sampled),
+        similarities=all_similarities,
+        vectorizer_name=_vectorizer_name(vectorizer),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def calibrate(
+    function_full_name: str,
+    *,
+    rerun: bool = False,
+    samples: Optional[int] = None,
+    runs: int = 10,
+) -> CalibrationResult:
+    """Compute a threshold recommendation for `function_full_name`.
+
+    Args:
+        function_full_name: Fully-qualified target, e.g. `myapp.summarize`.
+        rerun: If True, sample inputs and re-execute the function. Hits APIs
+            and triggers any side effects. If False (default), only pull
+            existing golden outputs and measure diversity — no side effects.
+        samples: Number of goldens to pull (diversity) or inputs to sample
+            (rerun). Defaults to 30 for diversity, 3 for rerun.
+        runs: Re-executions per sampled input. Only used in rerun mode.
+    """
+    if rerun:
+        effective_samples = samples if samples is not None else 3
+        return _calibrate_rerun(function_full_name, samples=effective_samples, runs=runs)
+    effective_samples = samples if samples is not None else 30
+    return _calibrate_diversity(function_full_name, samples=effective_samples)
+
+
+# ---------------------------------------------------------------------------
+# Rendering for CLI
+# ---------------------------------------------------------------------------
+
+def format_pyproject_snippet(result: CalibrationResult) -> str:
+    if result.recommended_strategy == "exact":
+        return (
+            f'[tool.vectorwave.check."{result.function}"]\n'
+            f'strategy = "exact"\n'
+        )
+    threshold = result.recommended_threshold or 0.85
+    return (
+        f'[tool.vectorwave.check."{result.function}"]\n'
+        f'strategy = "{result.recommended_strategy}"\n'
+        f"threshold = {threshold:.3f}\n"
+    )
+
+
+def format_report(result: CalibrationResult) -> str:
+    lines = [
+        f"Calibration for '{result.function}' "
+        f"(mode={result.mode}, vectorizer={result.vectorizer_name or 'n/a'})",
+        f"  samples={result.sample_count}, pairs={result.pair_count}",
+        "",
+    ]
+    for p in PERCENTILES:
+        v = result.percentiles.get(p)
+        if v is not None:
+            lines.append(f"  p{p:<3} {v:.4f}")
+    lines.append("")
+    if result.recommended_threshold is None and result.recommended_strategy == "exact":
+        lines.append("Recommended strategy: exact (no threshold needed)")
+    else:
+        lines.append(
+            f"Recommended: strategy={result.recommended_strategy}, "
+            f"threshold={result.recommended_threshold:.4f}"
+        )
+    if result.notes:
+        lines.append("")
+        for note in result.notes:
+            lines.append(f"  note: {note}")
+    lines.append("")
+    lines.append("Add to pyproject.toml:")
+    lines.append("")
+    for ln in format_pyproject_snippet(result).splitlines():
+        lines.append(f"  {ln}")
+    return "\n".join(lines)

--- a/src/vectorwave/check/cli.py
+++ b/src/vectorwave/check/cli.py
@@ -1,0 +1,74 @@
+"""CLI surface for vectorwave-check: `vectorwave check <subcommand>`."""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+
+def _cmd_calibrate(args: argparse.Namespace) -> int:
+    from .calibrate import calibrate, format_report
+
+    try:
+        result = calibrate(
+            args.target,
+            rerun=args.rerun,
+            samples=args.samples,
+            runs=args.runs,
+        )
+    except RuntimeError as e:
+        print(f"calibrate: {e}", file=sys.stderr)
+        return 1
+
+    print(format_report(result))
+    return 0
+
+
+def add_check_subparser(subparsers: "argparse._SubParsersAction") -> None:
+    check = subparsers.add_parser(
+        "check",
+        help="Semantic regression testing tools (calibration, discovery)",
+    )
+    check_sub = check.add_subparsers(dest="check_cmd", required=True)
+
+    calibrate_p = check_sub.add_parser(
+        "calibrate",
+        help="Compute a recommended similarity threshold for a target function",
+    )
+    calibrate_p.add_argument(
+        "target",
+        help="Fully-qualified function name, e.g. 'myapp.summarize'",
+    )
+    calibrate_p.add_argument(
+        "--rerun",
+        action="store_true",
+        help=(
+            "Re-execute the function on sampled inputs to measure intrinsic "
+            "noise floor. Default mode only reads existing golden outputs."
+        ),
+    )
+    calibrate_p.add_argument(
+        "--samples",
+        type=int,
+        default=None,
+        help=(
+            "Number of goldens (diversity mode) / inputs (rerun mode) to use. "
+            "Defaults: 30 (diversity), 3 (rerun)."
+        ),
+    )
+    calibrate_p.add_argument(
+        "--runs",
+        type=int,
+        default=10,
+        help="Re-executions per sampled input. Only used with --rerun. Default: 10.",
+    )
+    calibrate_p.set_defaults(func=_cmd_calibrate)
+
+
+def main(argv: Optional[list] = None) -> int:
+    """Entry point for direct invocation (e.g. `python -m vectorwave.check.cli ...`)."""
+    parser = argparse.ArgumentParser(prog="vectorwave-check")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    add_check_subparser(sub)
+    args = parser.parse_args(argv)
+    return args.func(args) or 0

--- a/src/vectorwave/check/config.py
+++ b/src/vectorwave/check/config.py
@@ -1,0 +1,75 @@
+"""Config resolution for the vectorwave-check plugin.
+
+Priority (highest first):
+    1. Marker kwargs (or fixture call kwargs)
+    2. ``[tool.vectorwave.check."<target>"]`` table in pyproject.toml
+    3. ``[tool.vectorwave.check]`` table in pyproject.toml
+    4. Built-in defaults
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    import tomllib
+except ImportError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+DEFAULTS: Dict[str, Any] = {
+    "strategy": "auto",
+    "threshold": 0.85,
+    "limit": 10,
+    "mocks": None,
+}
+
+_VALID_STRATEGIES = {"auto", "exact", "similarity", "llm"}
+
+
+def _load_check_table(rootpath: Path) -> Dict[str, Any]:
+    pyproject = rootpath / "pyproject.toml"
+    if not pyproject.exists():
+        return {}
+    with open(pyproject, "rb") as f:
+        data = tomllib.load(f)
+    return data.get("tool", {}).get("vectorwave", {}).get("check", {}) or {}
+
+
+def resolve_config(
+    target: str,
+    overrides: Dict[str, Any],
+    *,
+    pytestconfig: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Resolve config for a single target by layering sources.
+
+    ``overrides`` carries marker kwargs or fixture call kwargs. Only keys
+    whose value is not ``None`` win against the lower layers — pytest markers
+    populate kwargs eagerly, and a ``None`` should mean "fall back."
+    """
+    cfg: Dict[str, Any] = dict(DEFAULTS)
+
+    if pytestconfig is not None:
+        table = _load_check_table(Path(pytestconfig.rootpath))
+        defaults_from_toml = {k: v for k, v in table.items() if not isinstance(v, dict)}
+        for k, v in defaults_from_toml.items():
+            if k in DEFAULTS:
+                cfg[k] = v
+        per_fn = table.get(target)
+        if isinstance(per_fn, dict):
+            for k, v in per_fn.items():
+                if k in DEFAULTS:
+                    cfg[k] = v
+
+    for k in DEFAULTS:
+        if k in overrides and overrides[k] is not None:
+            cfg[k] = overrides[k]
+
+    if cfg["strategy"] not in _VALID_STRATEGIES:
+        raise ValueError(
+            f"Invalid strategy '{cfg['strategy']}' for target '{target}'. "
+            f"Expected one of: {sorted(_VALID_STRATEGIES)}"
+        )
+
+    return cfg

--- a/src/vectorwave/check/plugin.py
+++ b/src/vectorwave/check/plugin.py
@@ -1,0 +1,175 @@
+"""Pytest plugin entry point for VectorWave Check.
+
+Two surfaces:
+
+* A ``vectorwave`` marker that fully drives a regression check on a target
+  function (declarative).
+* A ``vw_replay`` fixture that returns the replay callable for programmatic
+  inspection (imperative).
+
+The marker is the lead. The fixture is for power-users who want to keep
+their own assertions / debugging logic around the replay result.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from .config import resolve_config
+from .report import format_failure_summary
+
+
+@dataclass
+class ReplayResult:
+    """Plugin-facing wrapper around ``VectorWaveReplayer.replay()``'s dict."""
+
+    function: str
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    updated: int = 0
+    failures: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def passed_all(self) -> bool:
+        return self.error is None and self.failed == 0 and self.total > 0
+
+    def report(self) -> str:
+        if self.error:
+            return f"vectorwave: replay failed to start — {self.error}"
+        return format_failure_summary(
+            self.function, self.total, self.failed, self.failures
+        )
+
+    @classmethod
+    def from_raw(cls, raw: Dict[str, Any]) -> "ReplayResult":
+        return cls(
+            function=raw.get("function", "?"),
+            total=raw.get("total", 0),
+            passed=raw.get("passed", 0),
+            failed=raw.get("failed", 0),
+            updated=raw.get("updated", 0),
+            failures=raw.get("failures", []),
+            error=raw.get("error"),
+        )
+
+
+def _run_replay(
+    *,
+    target: str,
+    strategy: str,
+    threshold: float,
+    limit: int,
+    mocks: Optional[Dict[str, Any]],
+) -> ReplayResult:
+    """Dispatch to the right replayer based on strategy.
+
+    Imports are local to keep plugin import-time cheap — constructing a
+    replayer hits Weaviate, which we want to avoid during pytest collection.
+    """
+    from vectorwave.utils.replayer import VectorWaveReplayer
+    from vectorwave.utils.replayer_semantic import SemanticReplayer
+
+    if strategy == "exact":
+        raw = VectorWaveReplayer().replay(
+            function_full_name=target, limit=limit, mocks=mocks
+        )
+    elif strategy == "similarity" or strategy == "auto":
+        raw = SemanticReplayer().replay(
+            function_full_name=target,
+            limit=limit,
+            similarity_threshold=threshold,
+            semantic_eval=False,
+            mocks=mocks,
+        )
+    elif strategy == "llm":
+        raw = SemanticReplayer().replay(
+            function_full_name=target,
+            limit=limit,
+            similarity_threshold=None,
+            semantic_eval=True,
+            mocks=mocks,
+        )
+    else:
+        raise ValueError(f"Unknown strategy: {strategy}")
+
+    return ReplayResult.from_raw(raw)
+
+
+def pytest_configure(config: "pytest.Config") -> None:
+    config.addinivalue_line(
+        "markers",
+        "vectorwave(target, strategy='auto', threshold=0.85, limit=10, mocks=None): "
+        "run a VectorWave semantic regression check on `target` "
+        "(fully-qualified function name) against its golden data.",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: "pytest.Function") -> Optional[bool]:
+    """Intercept tests marked with @pytest.mark.vectorwave.
+
+    Returning True signals pytest that the call has been handled and the
+    test function body should not be executed. Returning None falls through
+    to the default caller for unmarked tests.
+    """
+    marker = pyfuncitem.get_closest_marker("vectorwave")
+    if marker is None:
+        return None
+
+    target = marker.kwargs.get("target")
+    if not target:
+        pytest.fail(
+            "@pytest.mark.vectorwave requires a `target` kwarg "
+            "(fully-qualified function name, e.g. 'myapp.summarize').",
+            pytrace=False,
+        )
+
+    cfg = resolve_config(target, marker.kwargs, pytestconfig=pyfuncitem.config)
+    result = _run_replay(
+        target=target,
+        strategy=cfg["strategy"],
+        threshold=cfg["threshold"],
+        limit=cfg["limit"],
+        mocks=cfg["mocks"],
+    )
+
+    if not result.passed_all:
+        pytest.fail(result.report(), pytrace=False)
+    return True
+
+
+@pytest.fixture
+def vw_replay(pytestconfig: "pytest.Config"):
+    """Imperative replay callable. Returns a ``ReplayResult``."""
+
+    def _call(
+        target: str,
+        *,
+        strategy: Optional[str] = None,
+        threshold: Optional[float] = None,
+        limit: Optional[int] = None,
+        mocks: Optional[Dict[str, Any]] = None,
+    ) -> ReplayResult:
+        cfg = resolve_config(
+            target,
+            {
+                "strategy": strategy,
+                "threshold": threshold,
+                "limit": limit,
+                "mocks": mocks,
+            },
+            pytestconfig=pytestconfig,
+        )
+        return _run_replay(
+            target=target,
+            strategy=cfg["strategy"],
+            threshold=cfg["threshold"],
+            limit=cfg["limit"],
+            mocks=cfg["mocks"],
+        )
+
+    return _call

--- a/src/vectorwave/check/report.py
+++ b/src/vectorwave/check/report.py
@@ -1,0 +1,48 @@
+"""Format VectorWaveReplayer failures into a pytest-friendly string."""
+from __future__ import annotations
+
+import pprint
+from typing import Any, Dict, List
+
+
+_DEFAULT_TRUNCATE = 200
+
+
+def format_failure_summary(
+    function: str,
+    total: int,
+    failed: int,
+    failures: List[Dict[str, Any]],
+    *,
+    truncate: int = _DEFAULT_TRUNCATE,
+) -> str:
+    if total == 0:
+        return f"vectorwave: no golden samples found for '{function}' — nothing to compare against."
+
+    lines = [
+        f"vectorwave: {failed}/{total} regression check(s) failed on '{function}'",
+        "",
+    ]
+    for failure in failures:
+        uuid = failure.get("uuid", "?")
+        reason = failure.get("reason") or "mismatch"
+        golden_tag = " [GOLDEN]" if failure.get("is_golden") else ""
+        lines.append(f"  UUID {uuid}  {reason}{golden_tag}")
+        inputs = failure.get("inputs") or {}
+        if inputs:
+            lines.append(f"    inputs:   {_truncate(pprint.pformat(inputs, width=88, depth=2), truncate)}")
+        expected = failure.get("expected", "")
+        actual = failure.get("actual", "")
+        lines.append(f"    expected: {_truncate(repr(expected), truncate)}")
+        lines.append(f"    actual:   {_truncate(repr(actual), truncate)}")
+        if failure.get("error"):
+            lines.append(f"    error:    {failure['error']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _truncate(s: str, n: int) -> str:
+    if len(s) <= n:
+        return s
+    return s[: n - 3] + "..."

--- a/src/vectorwave/cli/__init__.py
+++ b/src/vectorwave/cli/__init__.py
@@ -263,6 +263,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="List Python processes currently running with VectorWave imported",
     ).set_defaults(func=cmd_info)
 
+    from vectorwave.check.cli import add_check_subparser
+    add_check_subparser(subparsers)
+
     return parser
 
 


### PR DESCRIPTION
## Summary

Folds VectorCheck's responsibilities into VectorWave as a first-class submodule. Two surfaces ship together so the 1.0 story is complete:

- a pytest plugin that drives golden-data regression checks from a marker or a fixture, and
- a `vectorwave check calibrate` CLI that recommends a sensible similarity threshold per function instead of leaving it to a magic number in the README.

This is the first piece of the path to archive the standalone VectorCheck repo after 1.0 ships.

## Changes

### New submodule: `vectorwave.check`

Marker (declarative, lead surface):

```python
@pytest.mark.vectorwave(
    target="myapp.summarize",
    strategy="similarity",   # exact | similarity | llm | auto
    threshold=0.85,
    limit=10,
    mocks={"myapp.openai.client": fake},
)
def test_summarize_regression():
    pass
```

Fixture (imperative, for inspection / debugging):

```python
def test_summarize_regression(vw_replay):
    result = vw_replay("myapp.summarize", strategy="similarity", threshold=0.85)
    assert result.passed_all, result.report()
```

Strategy `auto` maps to `similarity` for 1.0. Hybrid auto-escalation to `llm` is deferred to 1.1.

### Layered config

Priority (highest wins):

1. Marker / fixture kwargs
2. `[tool.vectorwave.check."<target>"]` in `pyproject.toml`
3. `[tool.vectorwave.check]` global defaults
4. Built-in defaults (`strategy="auto"`, `threshold=0.85`, `limit=10`)

### Implementation

- `pytest_pyfunc_call(tryfirst=True)` intercepts marker-bearing tests; the test body can stay `pass`.
- Replayer imports are deferred until a marker actually fires, so plugin load does not touch Weaviate.
- The marker dispatches to the existing `VectorWaveReplayer` (exact) or `SemanticReplayer` (similarity / llm) — no new replay engine.

### CLI: `vectorwave check calibrate <target>`

Reports `p5 / p10 / p25 / p50 / p75 / p95` of pairwise cosine similarity and a recommended threshold. Two modes:

- **diversity** (default, cheap): pulls existing golden outputs for the target and computes pairwise similarity across them. No function calls, no side effects.
- **rerun** (opt-in via `--rerun`): samples golden inputs and re-executes the function N times each, computing pairwise similarity within each input group. Hits the real function and any APIs it calls; this is the honest noise-floor measurement.

Recommendation logic:

- p5 of the pair distribution is the default recommended threshold.
- If `p5 > 0.99` and `p95 > 0.99`: recommend `strategy="exact"` (no threshold).
- If `p5 < 0.6`: warn that similarity will be noisy and recommend `strategy="llm"`.

Output ends with a ready-to-paste `[tool.vectorwave.check."<target>"]` pyproject snippet.

### Build

- Register `pytest11` entry point for the plugin.
- Add `tomli>=2.0; python_version < '3.11'` for `pyproject.toml` reading on 3.10.

## Test Results

25 tests under `src/tests/check/` all pass:

- 8 plugin smoke tests via `pytester` — marker registration, missing-target error, fixture injection, pass/fail/error replay paths, invalid strategy, and per-function config layering.
- 17 calibration unit tests — cosine, percentile (with linear interpolation), pairwise enumeration, summarize logic (normal / deterministic / noisy / empty), and both formatters.

End-to-end calibration against real golden data is left to `nightly_live`.

`flake8` hard-errors: 0. Style: 0.