### PR TITLE
chore(release): 1.0 prep — ADRs, CHANGELOG, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+All notable changes to VectorWave are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-05-20
+
+The 1.0 release shifts VectorWave from a Weaviate-coupled framework into
+a backend-neutral observability + regression-testing system, and folds
+the standalone VectorCheck project into VectorWave as a first-class
+pytest plugin.
+
+Highlights:
+
+- **Pytest plugin** for semantic regression testing — write a one-line
+  marker, get golden-data replay + similarity assertion inside your
+  normal `pytest` run.
+- **Lite mode** (LanceDB) — drop Docker for local development; install
+  `vectorwave[lite]` and you're running.
+- **OpenTelemetry mirror** — VW spans show up in your existing OTel
+  stack alongside the rest of your service traces.
+- **Calibration CLI** — `vectorwave check calibrate <target>`
+  replaces the magic-number threshold with a percentile-backed
+  recommendation.
+
+Benchmark anchor: `@vectorize` adds ~11.4 µs per call (median) on top
+of a bare Python function on Darwin / CPython 3.12 / Apple Silicon.
+Full breakdown lives in `src/tests/benchmarks/`. For any function
+doing >1 ms of real work, the wrapper tax is in the noise.
+
+### Added
+
+- **Pytest plugin** (`vectorwave.check`). `@pytest.mark.vectorwave(target=...,
+  strategy=..., threshold=..., limit=..., mocks=...)` drives a
+  regression check from a marker; `vw_replay` fixture is the imperative
+  variant. Config is layered from marker kwargs through
+  `[tool.vectorwave.check."<target>"]` and `[tool.vectorwave.check]`
+  tables in `pyproject.toml`. See ADR-0002.
+- **`vectorwave check calibrate <target>` CLI**. Reports p5/p10/p25/p50/p75/p95
+  of pairwise cosine similarity and recommends a threshold. Two modes:
+  default `diversity` (no function calls; reads existing goldens) and
+  opt-in `--rerun` (samples inputs and re-executes the function for the
+  honest noise-floor measurement). Recommends `strategy="exact"` for
+  deterministic targets and `strategy="llm"` for highly variable ones.
+- **Lite mode** — embedded LanceDB backend via the new `VectorStore`
+  protocol. Pro mode (Weaviate) remains the default; opt into Lite with
+  `pip install vectorwave[lite]` and `VECTORWAVE_MODE=lite`. New
+  backends are now a single-file addition. See ADR-0001.
+- **OpenTelemetry mirror** — VW spans are projected into OTel when
+  `OTEL_SERVICE_NAME` (or `VECTORWAVE_OTEL=1`) is set. Opt-in extras:
+  `pip install vectorwave[otel]`. VW's own pipeline is unchanged — OTel
+  is a mirror, not a replacement. See ADR-0003.
+- **Runtime indicator** — when VectorWave activates in a process, the
+  process registers itself with mode, OTel state, Rust-core status, and
+  instrumented modules. `vectorwave info` lists every live VW process.
+- **`vectorwave dev shell`** — drop into a subshell with `WEAVIATE_*`
+  env vars exported, so demos and `test_ex/` scripts work without
+  manual env wiring.
+- **`vectorwave dev seed`** — insert a small demo dataset of functions
+  + execution logs into a local Weaviate, no OpenAI key required.
+- **Pytest-benchmark fixture** for `@vectorize` overhead measurement
+  (`src/tests/benchmarks/`). Baseline saved as `v1.0-baseline`.
+- **Pre-commit secret-leak hook** (`scripts/check_secrets.py`) scans
+  staged content for common secret patterns before allowing the commit.
+- **ADR directory** (`docs/adr/`) capturing the 1.0 load-bearing
+  decisions: VectorStore abstraction, pytest plugin design, OTel mirror.
+
+### Changed
+
+- Vectorizer config migrated from `vectorizer_config` to `vector_config`
+  (Dep024 deprecation cleanup).
+- `Contributing.md` rewritten as a full contribution guide covering
+  setup, the e2e fixture model, and the PR workflow.
+
+### Fixed
+
+- **Concurrency**: `.vectorwave_functions_cache.json` is now lock-guarded,
+  and the batch manager shutdown is idempotent so duplicate calls during
+  interpreter teardown no longer raise.
+- **Safety**: stricter input validation, async-safety hardening in the
+  tracer, parameterized filters to prevent query injection in
+  Weaviate-backed lookups, and a source-leak warning when sensitive keys
+  match captured arguments.
+- **Cache**: `None`-returning functions can now hit the semantic cache
+  via a sentinel value instead of being treated as misses.
+- **Tracer**: three correctness issues in span logging — race in the
+  background logger, attribute capture for kwargs-only signatures, and
+  duplicate-span emission under exceptions.
+- **Lite store**: `LanceVectorStore` no longer requires `pandas` as a
+  hard dependency.
+- **CI**: nightly live-API job exits cleanly when no `@pytest.mark.live`
+  tests collect (instead of returning a "no tests selected" error).
+- **Pro tests**: `clean_weaviate` fixture forces Pro mode and drops the
+  cached `VectorStore` singleton so cross-test isolation holds.
+
+### Tests / Build / CI
+
+- Real e2e test conversion: database, healer, auto-metadata generator,
+  replayer, tracer paths now run against a real backend instead of
+  mocks. VCR cassettes for OpenAI-dependent tests keep them
+  deterministic without burning credits.
+- Testcontainers-backed Weaviate fixture replaces hand-rolled docker
+  invocations.
+- PR workflow updated for the e2e fixture model; nightly live-API job
+  added; redundant `maturin develop` step dropped in favor of pip's
+  maturin backend.
+- New optional dependency groups: `lite` (LanceDB), `otel`
+  (OpenTelemetry SDK + OTLP exporter), `dev` (full test toolchain
+  including testcontainers and vcrpy).
+
+### Removed
+
+- The standalone **VectorCheck** repository (`cozymori/vectorcheck`) is
+  superseded by the bundled `vectorwave.check` plugin and will be
+  archived. No code-level removal in this release — the migration is
+  one-directional (out of VectorCheck, into VectorWave).
+
+## [0.3.0] - 2026-02-19
+
+Last pre-1.0 release. See the git history for details
+(`git log v0.2.9..v0.3.0`).

--- a/docs/adr/0001-vectorstore-abstraction.md
+++ b/docs/adr/0001-vectorstore-abstraction.md
@@ -1,0 +1,97 @@
+# ADR-0001: VectorStore abstraction and Lite/Pro split
+
+- Status: Accepted
+- Date: 2026-05-10
+
+## Context
+
+VectorWave shipped with Weaviate hard-coded as the only backend. That
+meant:
+
+- Every test, demo, and contributor onboarding required Docker + a
+  Weaviate container. The README's "quick start" took 5+ minutes on a
+  cold machine.
+- Storage logic was spread across `database/db.py`, `database/dataset.py`,
+  the tracer, the replayer, and the auto-injector. Every new feature
+  reimplemented "query collection X with filter Y."
+- Functions like `get_cached_client()` and the Rust `RustBatchManager`
+  assumed Weaviate semantics (gRPC client, server-side vectorization)
+  and could not be swapped without rewriting callers.
+- We wanted a low-friction local-only mode for quick iteration, but
+  could not introduce one without touching every storage call site.
+
+A backend split was necessary before any further feature work landed.
+
+## Decision
+
+Introduce a `VectorStore` protocol in `src/vectorwave/store/base.py` that
+defines the operations the rest of VectorWave actually needs:
+
+- `query(collection, filters, sort_by, limit) -> records`
+- `fetch_by_id(collection, uuid) -> record | None`
+- `update(collection, uuid, properties)`
+- `insert(collection, properties)`
+- collection-existence + schema-management helpers
+
+Two backends implement the protocol:
+
+- **Pro mode** (`store/weaviate_store.py`) — the existing Weaviate path,
+  including server-side vectorization, the Rust batch manager, and the
+  golden-data lifecycle. Default for anyone who already has a Weaviate
+  instance configured.
+- **Lite mode** (`store/lance_store.py`) — embedded LanceDB. Zero
+  Docker, zero ports, single on-disk directory. Optional dependency
+  (`pip install vectorwave[lite]`).
+
+A single entry point `get_vector_store()` (in `src/vectorwave/store/__init__.py`)
+returns the singleton for the configured mode. All other modules call
+this — no direct Weaviate or Lance imports anywhere else.
+
+Mode selection is environment-driven (`VECTORWAVE_MODE=lite|pro`,
+defaults to Pro for backward compatibility).
+
+## Consequences
+
+**Wins:**
+
+- New backends are a single file. The PR that added LanceDB touched one
+  new module + the factory; no call-site changes elsewhere.
+- Local tests run without Docker. `pytest src/tests/` against the Lite
+  backend completes in a fraction of the time it took to spin up
+  Weaviate.
+- Storage concerns are now centralized. Future migrations (schema
+  changes, batching strategy changes) live in one place.
+- Pro-mode behavior is unchanged for existing users — `VECTORWAVE_MODE`
+  defaults preserve the prior wiring.
+
+**Costs:**
+
+- A small set of Weaviate features (server-side `text2vec-openai`,
+  hybrid search, distributed batching) are unavailable in Lite mode.
+  This is documented in the Lite mode section of the README and
+  surfaces as runtime warnings, not silent fallback.
+- Two backends means two test matrices in CI (Pro via testcontainers
+  Weaviate, Lite via temp directory). The cost is real but bounded.
+- The protocol records (`StoreRecord`, etc.) leak some Weaviate-shaped
+  ergonomics (`.uuid`, `.properties`). We accept this for 1.0 and
+  revisit if/when a third backend arrives.
+
+## Alternatives Considered
+
+1. **Stay on Weaviate, fix DX instead.** Improve testcontainers setup,
+   add docker-compose presets. Rejected — the Docker dependency itself
+   was the friction; faster Docker is still Docker.
+2. **Use a generic vector-DB ORM** (e.g. LangChain's vector store
+   interface). Rejected — those abstractions are CRUD-only and miss the
+   Weaviate-specific features VectorWave already relies on (filters,
+   custom properties, golden-data joins). Wrapping a wrapper would have
+   doubled the abstraction without solving the friction.
+3. **Per-call backend selection.** Let each `@vectorize` choose its
+   store. Rejected — every VW deployment we know of standardizes on one
+   backend per environment; per-call selection adds config surface
+   nobody asked for.
+
+## References
+
+- Related memory: project-architecture-shift-2026-05.
+- Related commits: `2b0107a feat(store): add Lite mode (LanceDB) via VectorStore abstraction (#95)`, `a118193 feat(store): finish Lite mode coverage across read/write paths`.

--- a/docs/adr/0002-pytest-plugin-design.md
+++ b/docs/adr/0002-pytest-plugin-design.md
@@ -1,0 +1,128 @@
+# ADR-0002: Pytest plugin as the primary surface for semantic regression testing
+
+- Status: Accepted
+- Date: 2026-05-18
+
+## Context
+
+VectorWave records every `@vectorize`d call: inputs, outputs, status,
+vectors. That dataset is the basis for regression testing — re-run a
+function against its golden inputs and verify the output is still
+"close enough" by exact match, embedding similarity, or LLM judgment.
+The engine for this already lived in `SemanticReplayer`
+(`src/vectorwave/utils/replayer_semantic.py`).
+
+What did not exist was a way for users to *run* that check inside their
+normal development loop. The standalone VectorCheck repo shipped a `vw
+test` CLI, but that put adoption behind a separate install, a separate
+config file (`vwtest.ini`), and a separate test runner that nobody's CI
+already calls. Friction was high enough that the VectorCheck repo had
+zero outside users.
+
+For 1.0 we needed a way to fold this capability into VectorWave itself
+with a single decision: how should users *invoke* a regression check?
+
+## Decision
+
+Ship a pytest plugin as the primary surface, under
+`src/vectorwave/check/`. Registered via the `pytest11` entry point.
+
+Two access patterns, both supported:
+
+- **Declarative marker** (lead surface):
+
+  ```python
+  @pytest.mark.vectorwave(
+      target="myapp.summarize",
+      strategy="similarity",
+      threshold=0.85,
+      limit=10,
+  )
+  def test_summarize_regression():
+      pass
+  ```
+
+  The marker fully drives the check via `pytest_pyfunc_call(tryfirst=True)`.
+  The test body stays empty — the marker *is* the test.
+
+- **Imperative fixture** (for inspection / debugging):
+
+  ```python
+  def test_summarize_regression(vw_replay):
+      result = vw_replay("myapp.summarize", strategy="similarity", threshold=0.85)
+      assert result.passed_all, result.report()
+  ```
+
+  Same engine, but the caller gets the `ReplayResult` object and can
+  inspect failures programmatically.
+
+Configuration is layered, highest priority wins:
+
+1. Marker / fixture call kwargs.
+2. `[tool.vectorwave.check."<target>"]` in `pyproject.toml`.
+3. `[tool.vectorwave.check]` global defaults.
+4. Built-in defaults (`strategy="auto"`, `threshold=0.85`, `limit=10`).
+
+Strategy values: `exact`, `similarity`, `llm`, `auto`. For 1.0, `auto`
+maps to `similarity`. Hybrid auto-escalation (similarity → LLM judge on
+borderline) is deferred to a later release.
+
+Replayer imports are deferred until a marker actually fires, so plugin
+load does not touch Weaviate. This is enforced by lazy imports inside
+`_run_replay`, not by convention.
+
+## Consequences
+
+**Wins:**
+
+- Adoption cost is one line in `conftest.py` (or zero — entry point
+  auto-loads). No new CLI, no new config file, no new test runner. The
+  user keeps `pytest` and adds a marker.
+- Failure output integrates with pytest's existing reporters: `-v`,
+  `-x`, JUnit XML, pytest-html, IDE plugins. We didn't have to build
+  any of that.
+- `pyproject.toml` is the only config surface. One file, standard
+  format, machine-editable. `vw calibrate --save` outputs paste-ready
+  TOML for this exact reason.
+- The standalone `vw test` CLI from the VectorCheck repo becomes
+  redundant. VectorCheck can be archived after 1.0.
+
+**Costs:**
+
+- The marker hides the test body. A reader who doesn't know the plugin
+  may not understand why `def test_x(): pass` is a real test. We
+  mitigate with an explicit marker docstring registered in
+  `pytest_configure` and a one-line note in the project README, but the
+  surprise factor is real.
+- The lazy-import discipline is enforced by structure, not by lint. A
+  future contributor adding a module-level `SemanticReplayer()` to
+  `plugin.py` would re-introduce the Weaviate-at-import problem
+  silently. Captured in the module docstring.
+- Calibration (`vectorwave check calibrate`) lives in the same submodule
+  but is its own CLI, not a pytest mode. We accepted the split because
+  calibration is a one-shot exploration step, not a per-test check.
+
+## Alternatives Considered
+
+1. **Keep the standalone CLI (`vw test`) and extend it.** Rejected —
+   no team adds a second test runner to their CI. The friction that
+   killed VectorCheck's adoption would survive intact.
+2. **Fixture only, no marker.** Rejected — for the common case ("run
+   regression for function X with default threshold"), the fixture
+   forces three lines of boilerplate (`result = vw_replay(...)`,
+   assert, report). The marker is one line.
+3. **Marker only, no fixture.** Rejected — power users with custom
+   golden-curation logic, batched replay across many targets, or
+   non-standard assertion shapes need a programmatic handle. The
+   fixture is cheap to ship and answers those use cases without forcing
+   them to bypass the plugin entirely.
+4. **Custom `vwtest.ini` for config, like VectorCheck did.**
+   Rejected — `pyproject.toml` already exists in every Python project
+   that ships, has tooling support (`tomllib`, IDE highlighting), and
+   keeps VW config next to the rest of the build config.
+
+## References
+
+- Related memory: project-vectorwave-1-0-scope.
+- Related modules: `src/vectorwave/check/plugin.py`, `src/vectorwave/check/config.py`, `src/vectorwave/check/calibrate.py`.
+- Related commits: `b4a4cae feat(check): add pytest plugin for semantic regression testing`, `a02b119 feat(check): add 'vectorwave check calibrate' for threshold recommendation` (merged as upstream `9e72ea7`).

--- a/docs/adr/0003-opentelemetry-mirror.md
+++ b/docs/adr/0003-opentelemetry-mirror.md
@@ -1,0 +1,95 @@
+# ADR-0003: Mirror spans to OpenTelemetry instead of replacing VW's pipeline
+
+- Status: Accepted
+- Date: 2026-05-11
+
+## Context
+
+VectorWave's tracer captures per-call spans: timing, status, error
+info, input vectors, return value, and the function's identity. These
+spans are written to the `VectorWaveExecutions` collection where they
+power semantic search over execution history, drift detection,
+self-healing, and the golden-data pipeline.
+
+A growing fraction of users already have an OpenTelemetry-based
+observability stack — Datadog, Honeycomb, Jaeger, Grafana Tempo. Those
+users want VW's per-function timings inside the same dashboards they
+use for the rest of their service. The asks have been consistent:
+
+- "I can see `@vectorize`d calls in VW's UI, but not in our Datadog
+  service map."
+- "Our SRE wants p95 latency by endpoint, and VectorWave's own search
+  isn't where they look."
+
+The choice was between treating VW's tracer as the primary system or as
+one of several consumers of a shared trace stream.
+
+## Decision
+
+Add an optional OpenTelemetry exporter that **mirrors** VW spans into
+the OTel pipeline. VW's own storage path is unchanged. Both write
+sinks fire from the same `_perform_background_logging` step.
+
+Specifically:
+
+- A new module `src/vectorwave/monitoring/otel.py` constructs an OTel
+  `Tracer` once per process (singleton) using the standard
+  `OTEL_EXPORTER_OTLP_*` env vars.
+- The tracer in `src/vectorwave/monitoring/tracer.py` calls into it
+  inside `_perform_background_logging`, after VW's own write. Errors
+  in the OTel path are swallowed and logged — they must not break the
+  VW path.
+- Activation is opt-in via `OTEL_SERVICE_NAME` (or
+  `VECTORWAVE_OTEL=1`). If neither is set, the OTel path is a no-op
+  and the OTel libs aren't even imported.
+- The OTel deps are an optional extra: `pip install vectorwave[otel]`.
+
+## Consequences
+
+**Wins:**
+
+- Existing OTel users get VW spans for free. Service maps, span search,
+  alert rules — all the OTel-stack tooling works without changes on
+  VW's side.
+- VW's own pipeline keeps full semantic context (input vectors,
+  return-value embedding, drift score). Nothing is lost in the OTel
+  projection.
+- Users without an OTel stack pay zero — no imports, no exporter
+  threads, no extra latency. Verified by the runtime indicator
+  showing `otel=off` for unconfigured processes.
+
+**Costs:**
+
+- Double-write on the hot path. Both VW's batch insert and the OTel
+  export run in the background logger. Measured cost is well below the
+  wrapper overhead (see ADR `benchmarks/v1.0-baseline`), but the cost
+  isn't zero.
+- The OTel projection is lossy by necessity — VW spans carry vectors
+  and Python objects that don't fit OTel's attribute model. We export
+  scalar attributes (status, latency, function name, hashed input
+  signature) and skip the rest. Documented in the OTel section of the
+  README.
+- One more configuration axis to test (`otel=on/off`). CI covers the
+  off-path via the main test suite and the on-path via the nightly
+  e2e job that wires a local collector.
+
+## Alternatives Considered
+
+1. **Replace VW's pipeline with OTel-only.** Rejected — VW's storage
+   isn't just "spans"; it's the substrate for semantic search, golden
+   data, drift detection, and self-healing. OTel's attribute model
+   can't express the vector fields without serializing them as strings,
+   at which point the search-time savings disappear.
+2. **OTel as primary, VW DB as optional.** Considered. Same problem
+   as #1 inverted — features that depend on the VW collection would
+   need a re-fetch path. Not worth the architectural inversion for the
+   share of users who want OTel.
+3. **No OTel integration; tell users to scrape their own.** Rejected —
+   the integration is small, the user demand is real, and "we won't"
+   answers the wrong question. The right question was: *primary or
+   mirror?*
+
+## References
+
+- Related modules: `src/vectorwave/monitoring/otel.py`, `src/vectorwave/monitoring/tracer.py`.
+- Related commit: `8313dc0 feat(monitoring): mirror VectorWave spans to OpenTelemetry (#29)`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,51 @@
+# Architectural Decision Records
+
+This directory captures the load-bearing design decisions in VectorWave.
+Each ADR is a short, dated record of a single choice: the problem we
+faced, the option we picked, what we gave up, and what we considered
+instead.
+
+The point isn't documentation completeness — it's giving the next person
+(future-us or a contributor) enough context to *not relitigate* a settled
+question, and enough context to *know when to relitigate* if the inputs
+change.
+
+## Format
+
+We use a lightweight [MADR](https://adr.github.io/madr/)-style template:
+
+```
+# ADR-NNNN: Title
+
+- Status: Proposed | Accepted | Superseded by ADR-XXXX
+- Date: YYYY-MM-DD
+
+## Context
+Why we needed to decide anything. What was painful or unclear before.
+
+## Decision
+What we chose. Be specific — name modules, signatures, knobs.
+
+## Consequences
+What this buys us and what it costs us. Include both.
+
+## Alternatives Considered
+Other paths we weighed, and why we didn't take them.
+```
+
+## Index
+
+| ID | Title | Status |
+|---|---|---|
+| [0001](0001-vectorstore-abstraction.md) | VectorStore abstraction and Lite/Pro split | Accepted |
+| [0002](0002-pytest-plugin-design.md) | Pytest plugin as primary surface for semantic regression testing | Accepted |
+| [0003](0003-opentelemetry-mirror.md) | Mirror spans to OpenTelemetry instead of replacing VW's pipeline | Accepted |
+
+## Conventions
+
+- Numbers are assigned in order, never reused, never renumbered.
+- Once Accepted, an ADR is immutable except to update its Status. If a
+  later decision overrides this one, mark the old ADR `Superseded by
+  ADR-XXXX` and write the new ADR — don't edit history.
+- ADRs are about *decisions*, not implementations. Don't paste large
+  code blocks. Cross-reference module paths instead (`src/vectorwave/...`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vectorwave"
-version = "0.3.0"
+version = "1.0.0"
 authors = [
     { name = "junyeonggim", email = "junyeonggim5@gmail.com" },
 ]
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Operating System :: OS Independent",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
 ]
 


### PR DESCRIPTION
## Summary

Bundles the three documentation/metadata changes that have to land
before the v1.0 tag is cut:

1. Seed the ADR directory with the three load-bearing 1.0 decisions
   (VectorStore abstraction, pytest plugin design, OTel mirror).
2. Add `CHANGELOG.md` in Keep-a-Changelog format with the full 0.3.0
   → 1.0 entry.
3. Bump `pyproject.toml` to `1.0.0` and flip the trove classifier from
   `3 - Alpha` to `5 - Production/Stable`.

No code or test changes — this is metadata + docs. After merge, the
next step is the `v1.0.0` tag + GitHub release, which will fire
`publish.yml` and push wheels to PyPI.

## Changes

### `docs/adr/`

- `README.md` — the conventions (MADR-lite, immutable once Accepted,
  decisions not implementations).
- `0001-vectorstore-abstraction.md` — why every storage call goes
  through a single protocol, what Lite mode gives up to drop Docker,
  and which alternatives were considered.
- `0002-pytest-plugin-design.md` — why marker + fixture, why
  `pyproject.toml` config, why `vw test` (the standalone CLI from
  VectorCheck) is being retired.
- `0003-opentelemetry-mirror.md` — why we send a projection of VW
  spans to OTel while keeping VW's own pipeline as the source of truth.

### `CHANGELOG.md`

Keep-a-Changelog format. The `[1.0.0]` entry covers the 28 commits
since `v0.3.0`:

- Added: pytest plugin, calibration CLI, Lite mode, OTel mirror,
  runtime indicator, `vectorwave dev shell` / `seed`, pytest-benchmark
  fixture, pre-commit secret-leak hook, ADR directory.
- Changed: vector_config migration, contribution guide rewrite.
- Fixed: cache-file lock, async-safety, query injection, sentinel
  cache, tracer correctness issues, LanceVectorStore pandas drop,
  nightly CI exit code, clean_weaviate isolation.
- Tests / Build / CI: e2e conversion across multiple paths, VCR
  cassettes, testcontainers, PR + nightly workflow updates, new
  `lite` / `otel` / `dev` extras.
- Removed: VectorCheck repo is superseded (archival is a separate
  follow-up; no code-level removal in this release).

Includes the benchmark anchor (~11.4 µs / call median wrapper
overhead) up front and cross-references ADR-0001..0003 inline.

### `pyproject.toml`

```diff
- version = "0.3.0"
+ version = "1.0.0"
...
- "Development Status :: 3 - Alpha",
+ "Development Status :: 5 - Production/Stable",
```

## Test Results

No code changes, so the existing test suite is unaffected. CI will
verify on push.

## Follow-up after merge

- `git tag v1.0.0` on the merge commit + `git push upstream v1.0.0`.
- Create the GitHub release from the tag. `publish.yml` triggers on
  release `published` and uploads wheels (linux/x86_64,
  windows/x86_64, macos/universal2) + sdist to PyPI.
- Archive the standalone VectorCheck repo and point its README at
  `vectorwave.check`.
- Launch blog post.