### PR TITLE
fix(ci): unbreak Linux wheel build for v1.0 publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 🐧 Linux (x86_64)
+          # 🐧 Linux (x86_64) — --find-interpreter so maturin discovers any
+          # Python inside the manylinux container (the default `python3` path
+          # is not always present in newer manylinux_2_28 images).
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            args: --release --out dist
+            args: --release --out dist --find-interpreter
           # 🪟 Windows (x86_64)
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -41,7 +43,10 @@ jobs:
           target: ${{ matrix.target }}
           args: ${{ matrix.args }}
           sccache: 'true'
-          manylinux: auto
+          # Pin manylinux explicitly (ignored on non-Linux targets). 2_28 is
+          # the modern manylinux image that ships multiple Python versions
+          # under /opt/python/, which maturin --find-interpreter can pick up.
+          manylinux: 2_28
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Hotfix for the broken v1.0.0 publish run.
[Workflow #26090705320](https://github.com/Cozymori/VectorWave/actions/runs/26090705320)
failed on Linux with:

```
maturin failed
  Caused by: Couldn't find any python interpreters from 'python3'.
```

Windows + macOS wheel jobs and the sdist job all passed. **Nothing was
uploaded to PyPI** because the release job needs every wheel job to
succeed first — so we can recover cleanly.

## Changes

Two targeted edits to `.github/workflows/publish.yml`:

1. Pin the Linux `manylinux` image to `2_28` instead of `auto`. The
   recent `PyO3/maturin-action` default skews newer than the image
   previous releases were built against, and its `python3` symlink
   is missing.
2. Add `--find-interpreter` to the Linux matrix's maturin args so it
   discovers whichever Python lives under `/opt/python/` inside the
   2_28 container.

Windows / macOS args are unchanged — host Python on those runners is
already discoverable.

## Recovery procedure (after merge)

```bash
gh workflow run publish.yml --repo Cozymori/VectorWave --ref main
```

`workflow_dispatch` is already enabled on the publish workflow. The
release event itself does not need to be re-fired; `maturin upload`
uses `--skip-existing`, so re-uploading the Windows/macOS wheels that
were built last time is a no-op if their artifacts already reach PyPI.

If `workflow_dispatch` ends up not having the release context the
upload step needs, the fallback is to delete + re-publish the
`v1.0.0` GitHub release after this PR lands, which will fire
`release: published` against the fixed workflow.

## Test Results

CI-only change; no code or test changes. The fix's effect can only be
verified by running the workflow against the new `publish.yml`.