### PR TITLE
fix(tracer): exclude injected keys from cache vector text

### DIFF
--- a/src/tests/monitoring/test_tracer.py
+++ b/src/tests/monitoring/test_tracer.py
@@ -421,3 +421,57 @@ def test_enable_alert_false_default_is_true(mock_tracer_deps):
     my_workflow()
 
     mock_alerter.notify.assert_called_once()
+
+
+def test_reserved_keys_excluded_from_cache_vector(mock_tracer_deps, monkeypatch):
+    """
+    Regression: the @vectorize decorator injects bookkeeping keys
+    (function_uuid, exec_source, trace_id) into call kwargs. Those must NOT
+    leak into the vectorized text — otherwise a stored execution embeds a
+    different input than the cache-lookup path (which only sees the caller's
+    own args) and the semantic cache can never hit at a sane threshold.
+    See tracer._RESERVED_VECTOR_KEYS.
+    """
+    from vectorwave.monitoring.tracer import _create_input_vector_data
+
+    class _SpyVectorizer:
+        def __init__(self):
+            self.texts = []
+
+        def embed(self, text):
+            self.texts.append(text)
+            return [0.0] * 8
+
+    spy = _SpyVectorizer()
+    monkeypatch.setattr(f"{TRACER_MODULE_PATH}.get_vectorizer",
+                        MagicMock(return_value=spy))
+
+    @trace_root()
+    @trace_span(capture_return_value=True)
+    def summarize(text, **_injected):
+        return f"summary of {text}"
+
+    summarize(
+        "hello world",
+        function_uuid="uuid-should-not-leak",
+        exec_source="REALTIME",
+        trace_id="trace-should-not-leak",
+    )
+
+    assert spy.texts, "vectorizer.embed was never called for the successful span"
+    stored_text = spy.texts[-1]
+
+    # Neither the reserved key names nor their values may appear in the vector.
+    for leaked in ("function_uuid", "exec_source",
+                   "uuid-should-not-leak", "REALTIME", "trace-should-not-leak"):
+        assert leaked not in stored_text, f"{leaked!r} leaked into cache vector text"
+
+    # The stored text must equal what the cache-lookup path builds from the
+    # caller's own args — so identical inputs embed to identical vectors.
+    expected = _create_input_vector_data(
+        func_name="summarize",
+        args=("hello world",),
+        kwargs={},
+        sensitive_keys=mock_tracer_deps["settings"].sensitive_keys,
+    )["text"]
+    assert stored_text == expected

--- a/src/vectorwave/monitoring/tracer.py
+++ b/src/vectorwave/monitoring/tracer.py
@@ -184,6 +184,12 @@ def _create_span_properties(
     return span_properties
 
 
+# Keys the @vectorize decorator injects into call kwargs for its own bookkeeping.
+# They must be excluded from the vectorized text so a stored execution embeds the
+# same input as the cache-lookup path (which only sees the caller's own args).
+_RESERVED_VECTOR_KEYS = frozenset({"function_uuid", "exec_source", "trace_id"})
+
+
 def _create_input_vector_data(
         func_name: str,
         args: tuple,
@@ -240,10 +246,19 @@ def _perform_background_logging(ctx: SpanContext):
         if vectorizer is not None:
             try:
                 if ctx.status == "SUCCESS" and ctx.capture_return_value:
+                    # The cache lookup embeds only the caller's original args/kwargs.
+                    # Match it here by stripping the keys the decorator injects
+                    # (function_uuid, exec_source, trace_id) — otherwise the stored
+                    # vector never aligns with the lookup vector and the semantic
+                    # cache can never hit at a sane threshold.
+                    clean_kwargs = {
+                        k: v for k, v in ctx.kwargs.items()
+                        if k not in _RESERVED_VECTOR_KEYS
+                    }
                     input_vector_data = _create_input_vector_data(
                         func_name=ctx.func.__name__,
                         args=ctx.args,
-                        kwargs=ctx.kwargs,
+                        kwargs=clean_kwargs,
                         sensitive_keys=ctx.tracer.settings.sensitive_keys
                     )
                     vector_to_add = vectorizer.embed(input_vector_data['text'])


### PR DESCRIPTION
## Summary
The semantic cache never hit — even an identical input capped near cosine 0.76, below the default 0.95 threshold — in both Pro and Lite mode. The storage path embedded the decorator's internal bookkeeping keys into the vector text while the cache-lookup path did not, so the two vectors never aligned.

## Bug Fix
`@vectorize` injects `function_uuid`, `exec_source`, and `trace_id` into call kwargs. In `monitoring/tracer.py`, `_perform_background_logging` embedded the full `ctx.kwargs`, so a stored execution's vector text contained e.g. `function_uuid: <uuid> exec_source: REALTIME`. The cache-lookup path (`utils/return_caching_utils.py`) embeds only the caller's own args, so the stored and looked-up vectors diverged and the semantic cache could not hit at any sane threshold.

**Fix:** strip a `_RESERVED_VECTOR_KEYS = {function_uuid, exec_source, trace_id}` set from the kwargs before vectorizing on the storage path, so stored and looked-up inputs embed identically.

## Changes
- `src/vectorwave/monitoring/tracer.py`
  - Add module-level `_RESERVED_VECTOR_KEYS`.
  - In `_perform_background_logging`, build `clean_kwargs` (kwargs minus reserved keys) and vectorize that instead of the raw `ctx.kwargs`.
- `src/tests/monitoring/test_tracer.py`
  - Add `test_reserved_keys_excluded_from_cache_vector`: a spy vectorizer asserts the injected keys/values never appear in the embedded text and that the stored text equals what the lookup path builds from the caller's args. The test fails on the old behavior.

## Test Results
- `test_reserved_keys_excluded_from_cache_vector` fails without the fix, passes with it.
- `pytest src/tests/monitoring/test_tracer.py src/tests/utils/test_return_caching.py` — 14 passed.
- flake8 hard-error select (E9,F63,F7,F82) — 0.
- End-to-end (Lite mode, HuggingFace embeddings): identical/paraphrased input now returns the cached result in ~0.03s (was a 2s re-execution); an unrelated query still misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)